### PR TITLE
Add inter-regional transmission capacity constraints to UC solver

### DIFF
--- a/.auto-claude/specs/003-add-transmission-capacity-constraints-between-grid/build-progress.txt
+++ b/.auto-claude/specs/003-add-transmission-capacity-constraints-between-grid/build-progress.txt
@@ -1,0 +1,135 @@
+=== AUTO-BUILD PROGRESS ===
+
+Project: Add Inter-Regional Transmission Capacity Constraints to UC Solver
+Spec: 003-add-transmission-capacity-constraints-between-grid
+Workspace: managed by orchestrator
+Started: 2026-03-05
+
+Workflow Type: feature
+Rationale: Extends existing UC solver with new flow variables, nodal balance constraints, and transmission capacity bounds. All current constraints remain intact. Natural dependency chain: data layer -> constraints -> solver -> decomposition/config -> export/regression.
+
+Session 1 (Planner):
+- Completed deep codebase investigation of src/uc/ module
+- Analyzed 9 existing constraint builders in constraints.py
+- Analyzed solver.py variable creation and solution extraction patterns
+- Analyzed decomposition.py RegionalDecomposer partition logic
+- Verified interconnections.yaml has all 9 OCCTO records
+- Verified regional_demand.yaml has all 10 region peak demands
+- Created implementation_plan.json (5 phases, 14 subtasks)
+- Created context.json with patterns and key decisions
+- Created init.sh environment setup script
+- Created build-progress.txt
+
+Phase Summary:
+- Phase 1 (Data Models & Interconnection Loader): 3 subtasks, depends on []
+  - Interconnection/InterconnectionFlow dataclasses
+  - InterconnectionLoader YAML loader
+  - Test factories + data layer tests
+- Phase 2 (Constraint Builder Functions): 3 subtasks, depends on [phase-1]
+  - add_transmission_capacity_constraints()
+  - add_nodal_balance_constraints()
+  - Constraint builder unit tests
+- Phase 3 (Solver Integration): 3 subtasks, depends on [phase-2]
+  - Flow variable creation + constraint wiring
+  - Flow result extraction
+  - Two-region integration test
+- Phase 4 (Decomposition Fallback & Configuration): 3 subtasks, depends on [phase-3]
+  - RegionalDecomposer fallback logic
+  - uc_config.yaml interconnection section
+  - Decomposition + config tests
+- Phase 5 (Result Export & Regression): 2 subtasks, depends on [phase-4]
+  - result_exporter.py flow data export
+  - Full regression test suite
+
+Services Involved:
+- main: Python UC solver module (src/uc/), the only service affected
+
+Files to Create:
+- src/uc/interconnection_loader.py
+- tests/test_uc_interconnection.py
+
+Files to Modify:
+- src/uc/models.py (Interconnection dataclass, UCParameters extension, UCResult extension)
+- src/uc/constraints.py (2 new constraint builders)
+- src/uc/solver.py (flow variables, constraint wiring, result extraction)
+- src/uc/decomposition.py (RegionalDecomposer fallback)
+- src/uc/__init__.py (exports)
+- src/uc/result_exporter.py (flow data export)
+- config/uc_config.yaml (interconnection toggle)
+- tests/conftest.py (make_interconnection factory)
+
+Parallelism Analysis:
+- Max parallel phases: 1
+- Recommended workers: 1
+- Sequential execution required (single service, tight dependency chain)
+- Each phase builds directly on the previous phase's output
+
+Key Architectural Decisions:
+1. Flow convention: f[ic,t] > 0 = flow from from_region to to_region
+2. Bidirectional bounds: -cap <= f <= cap
+3. Nodal balance REPLACES demand balance when interconnections active (conditional)
+4. Existing add_demand_balance_constraints() preserved unchanged
+5. RegionalDecomposer returns [params] when interconnections present
+6. Feature opt-in via uc_config.yaml interconnection.enabled (default: false)
+7. No flow cost in objective (flow is free; only generator costs matter)
+
+Risk Mitigations:
+- Existing 9 constraint builders remain untouched
+- Conditional branching in _add_all_constraints() based on interconnection presence
+- Full regression test suite run in phase 5
+- Two-region integration test validates end-to-end correctness
+
+=== STARTUP COMMAND ===
+
+To continue building this spec, run:
+
+  cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid
+  source auto-claude/.venv/bin/activate && python auto-claude/run.py --spec 003 --parallel 1
+
+Or run init.sh first to verify environment:
+
+  bash .auto-claude/specs/003-add-transmission-capacity-constraints-between-grid/init.sh
+
+=== END SESSION 1 ===
+
+=== SESSION: Subtask 5-2 Regression Verification ===
+
+Subtask 5-2: Regression Verification
+- Ran complete existing test suite to confirm no regressions
+- Results summary:
+  - test_uc_models.py: 79 passed (0 failures)
+  - test_uc_xml_loader.py: 52 passed, 2 skipped (0 failures)
+  - test_uc_solver.py: 47 passed (0 failures)
+  - test_uc_decomposition.py: 53 passed (0 failures)
+  - test_uc_interconnection.py: 48 passed (0 failures, all new tests)
+  - Full suite: 401 passed, 2 skipped, 1 warning (unrelated RuntimeWarning in ac_powerflow)
+
+Specific Verification:
+1. 9 existing constraint builders produce identical results:
+   - demand_balance: 2 tests pass
+   - capacity_bounds: 1 test passes
+   - min_uptime: 2 tests pass
+   - min_downtime: 2 tests pass
+   - ramp_rates: 3 tests pass
+   - maintenance: 3 tests pass
+   - reserve_margin: 3 tests pass
+   - storage SOC (pumped hydro): 7 tests pass
+   - storage SOC (battery): 3 tests pass
+   - storage integration: 3 tests pass
+
+2. Storage SOC constraints unaffected:
+   - All 13 storage/SOC tests pass unchanged
+   - Pumped hydro SOC bounds, charge/discharge mutual exclusion, balance equation verified
+   - Battery SOC tracking, fast cycle, terminal SOC constraint verified
+
+3. Decomposition strategies work as before when no interconnections present:
+   - Regional decomposition: 7 partition tests + 4 solve tests pass
+   - Fuel type decomposition: 4 partition tests + 2 solve tests pass
+   - Time window decomposition: 8 partition tests + 4 solve tests pass
+   - Result merging: 7 tests pass
+   - Factory: 6 tests pass
+   - Consistency/integrity: 4 tests pass
+
+Status: COMPLETED - All subtasks in implementation plan are now completed.
+
+=== END SUBTASK 5-2 ===

--- a/.auto-claude/specs/003-add-transmission-capacity-constraints-between-grid/implementation_plan.json
+++ b/.auto-claude/specs/003-add-transmission-capacity-constraints-between-grid/implementation_plan.json
@@ -1,0 +1,452 @@
+{
+  "feature": "Add inter-regional transmission capacity constraints to UC solver",
+  "workflow_type": "feature",
+  "workflow_rationale": "This adds new solver capability (flow variables, nodal balance, transmission limits) to the existing UC module. It extends rather than replaces existing code, and all current constraints remain intact. Follows a natural service dependency order: data layer -> constraints -> solver integration -> decomposition/config -> export/regression.",
+  "phases": [
+    {
+      "id": "phase-1-data-layer",
+      "name": "Data Models & Interconnection Loader",
+      "type": "implementation",
+      "description": "Create the Interconnection/InterconnectionFlow dataclasses, extend UCParameters and UCResult, build the YAML loader, and add test factory fixtures. This is the foundation that all subsequent phases depend on.",
+      "depends_on": [],
+      "parallel_safe": true,
+      "subtasks": [
+        {
+          "id": "subtask-1-1",
+          "description": "Add Interconnection and InterconnectionFlow dataclasses to src/uc/models.py. Add 'interconnections' field to UCParameters (List[Interconnection], default empty). Add 'interconnection_flows' field to UCResult (List[InterconnectionFlow], default empty). Interconnection has: id, name_en, from_region, to_region, capacity_mw, type with __post_init__ validation. InterconnectionFlow has: interconnection_id, flow_mw (List[float]) for per-timestep flow values.",
+          "service": "main",
+          "files_to_modify": [
+            "src/uc/models.py"
+          ],
+          "files_to_create": [],
+          "patterns_from": [
+            "src/uc/models.py"
+          ],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -c \"from src.uc.models import UCParameters, UCResult; p = UCParameters(); print('interconnections:', p.interconnections); r = UCResult(); print('flows:', r.interconnection_flows); print('OK')\"",
+            "expected": "OK"
+          },
+          "status": "completed",
+          "notes": "Added Interconnection and InterconnectionFlow dataclasses to src/uc/models.py. Added 'interconnections' field to UCParameters and 'interconnection_flows' field to UCResult. All 79 existing model tests pass unchanged. Committed as ed50495.",
+          "updated_at": "2026-03-05T12:29:36.411590+00:00"
+        },
+        {
+          "id": "subtask-1-2",
+          "description": "Create src/uc/interconnection_loader.py with InterconnectionLoader class. The load() method reads data/reference/interconnections.yaml using yaml.safe_load(), validates records, and returns List[Interconnection]. Follow the pattern from xml_loader.py (open with encoding='utf-8', log loaded count). Handle FileNotFoundError for missing YAML. Validate that all required fields (id, from_region, to_region, capacity_mw) are present in each record.",
+          "service": "main",
+          "files_to_modify": [],
+          "files_to_create": [
+            "src/uc/interconnection_loader.py"
+          ],
+          "patterns_from": [
+            "src/uc/xml_loader.py"
+          ],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -c \"from src.uc.interconnection_loader import InterconnectionLoader; loader = InterconnectionLoader(); ics = loader.load('data/reference/interconnections.yaml'); print(f'Loaded {len(ics)} interconnections'); assert len(ics) == 9; print('OK')\"",
+            "expected": "OK"
+          },
+          "status": "completed",
+          "notes": "Created src/uc/interconnection_loader.py with InterconnectionLoader class. The load() method reads YAML using yaml.safe_load(), validates required fields (id, from_region, to_region, capacity_mw), handles FileNotFoundError, and returns List[Interconnection]. All 9 interconnections load correctly from data/reference/interconnections.yaml. Follows xml_loader.py patterns (encoding='utf-8', get_logger, class structure). Committed as 7730f35.",
+          "updated_at": "2026-03-05T12:31:26.704879+00:00"
+        },
+        {
+          "id": "subtask-1-3",
+          "description": "Add make_interconnection() factory function to tests/conftest.py following the make_generator() pattern. Add basic unit tests in tests/test_uc_interconnection.py: test Interconnection dataclass validation (empty id, negative capacity, same from/to region), test InterconnectionLoader loads all 9 records from YAML, test loader raises FileNotFoundError for missing file. Update src/uc/__init__.py to export Interconnection and InterconnectionFlow.",
+          "service": "main",
+          "files_to_modify": [
+            "tests/conftest.py",
+            "src/uc/__init__.py"
+          ],
+          "files_to_create": [
+            "tests/test_uc_interconnection.py"
+          ],
+          "patterns_from": [
+            "tests/conftest.py",
+            "tests/test_uc_solver.py"
+          ],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -m pytest tests/test_uc_interconnection.py -v --tb=short 2>&1 | tail -20",
+            "expected": "passed"
+          },
+          "status": "completed",
+          "notes": "Added make_interconnection() factory function to tests/conftest.py following the make_generator() pattern. Created tests/test_uc_interconnection.py with 20 unit tests covering: Interconnection dataclass validation (empty id, negative capacity, zero capacity, same from/to region), InterconnectionFlow construction, InterconnectionLoader loads all 9 records from YAML with field verification, loader raises FileNotFoundError for missing file, and package exports (Interconnection and InterconnectionFlow importable from src.uc). Updated src/uc/__init__.py to export Interconnection and InterconnectionFlow. All 373 tests pass with no regressions. Committed as 07d681a.",
+          "updated_at": "2026-03-05T12:33:57.919105+00:00"
+        }
+      ]
+    },
+    {
+      "id": "phase-2-constraints",
+      "name": "Constraint Builder Functions",
+      "type": "implementation",
+      "description": "Add the two new constraint builder functions to constraints.py: add_transmission_capacity_constraints() and add_nodal_balance_constraints(). These follow the exact same modular pattern as the existing 9 constraint builders. The existing add_demand_balance_constraints() is preserved unchanged.",
+      "depends_on": [
+        "phase-1-data-layer"
+      ],
+      "parallel_safe": true,
+      "subtasks": [
+        {
+          "id": "subtask-2-1",
+          "description": "Add add_transmission_capacity_constraints(model, f, interconnections, timesteps) -> int to src/uc/constraints.py. For each interconnection ic and timestep t, add upper bound f[(ic.id, t)] <= ic.capacity_mw and lower bound f[(ic.id, t)] >= -ic.capacity_mw. Constraint names: tx_cap_ub_{ic.id}_t{t} and tx_cap_lb_{ic.id}_t{t}. Log count at INFO. Import Interconnection from models.",
+          "service": "main",
+          "files_to_modify": [
+            "src/uc/constraints.py"
+          ],
+          "files_to_create": [],
+          "patterns_from": [
+            "src/uc/constraints.py"
+          ],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -c \"from src.uc.constraints import add_transmission_capacity_constraints; print('Import OK')\"",
+            "expected": "Import OK"
+          },
+          "status": "completed",
+          "notes": "Added add_transmission_capacity_constraints() to src/uc/constraints.py. Imports Interconnection from src.uc.models. For each interconnection and timestep, adds upper bound (f <= capacity_mw) and lower bound (f >= -capacity_mw) constraints with naming pattern tx_cap_ub_{ic.id}_t{t} / tx_cap_lb_{ic.id}_t{t}. Logs constraint count at INFO level. Updated module docstring usage example. Verified import and functional test with 2 interconnections × 3 timesteps = 12 constraints. Committed as 4ad9243.",
+          "updated_at": "2026-03-05T12:36:03.989609+00:00"
+        },
+        {
+          "id": "subtask-2-2",
+          "description": "Add add_nodal_balance_constraints(model, p, f, generators, interconnections, timesteps, regional_demand) -> int to src/uc/constraints.py. Groups generators by generator.region. For each region r and timestep t: sum(p[g,t] for g in region_r) + sum(f[ic,t] for ic where to_region==r) - sum(f[ic,t] for ic where from_region==r) >= demand[r][idx]. regional_demand is Dict[str, List[float]] mapping region to demand series. Constraint names: nodal_bal_{region}_t{t}. Log count at INFO.",
+          "service": "main",
+          "files_to_modify": [
+            "src/uc/constraints.py"
+          ],
+          "files_to_create": [],
+          "patterns_from": [
+            "src/uc/constraints.py"
+          ],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -c \"from src.uc.constraints import add_nodal_balance_constraints; print('Import OK')\"",
+            "expected": "Import OK"
+          },
+          "status": "completed",
+          "notes": "Added add_nodal_balance_constraints() to src/uc/constraints.py. Groups generators by region, computes per-region generation + net imports (inflows minus outflows) >= regional demand for each region and timestep. Constraint names follow pattern nodal_bal_{region}_t{t}. Logs count at INFO level. Updated module docstring imports. Verified with import test and functional test (2 regions × 2 timesteps = 4 constraints). Committed as caab8de.",
+          "updated_at": "2026-03-05T12:38:23.929140+00:00"
+        },
+        {
+          "id": "subtask-2-3",
+          "description": "Add constraint builder unit tests to tests/test_uc_interconnection.py: (1) test_transmission_capacity_constraints: create a small PuLP model with 1 interconnection and 3 timesteps, verify 6 constraints added (2 per timestep), solve and verify flow within bounds. (2) test_nodal_balance_constraints: create 2 regions with 1 generator each + 1 interconnection, verify per-region balance constraints added, solve and verify region demands met. (3) test_flow_sign_convention: verify positive flow goes from from_region to to_region.",
+          "service": "main",
+          "files_to_modify": [
+            "tests/test_uc_interconnection.py"
+          ],
+          "files_to_create": [],
+          "patterns_from": [
+            "tests/test_uc_solver.py"
+          ],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -m pytest tests/test_uc_interconnection.py -v -k 'capacity or nodal or flow_sign' --tb=short 2>&1 | tail -20",
+            "expected": "passed"
+          },
+          "status": "completed",
+          "notes": "Added 16 constraint builder unit tests to tests/test_uc_interconnection.py: TestTransmissionCapacityConstraints (6 tests - constraint count, naming, upper/lower bound enforcement), TestNodalBalanceConstraints (5 tests - count, naming, demand met, infeasibility, multi-gen per region), TestFlowSignConvention (3 tests - positive/negative flow direction, magnitude matching). All 34 tests in the file pass. No regressions in existing UC tests (126 pass). Committed as 57d6335.",
+          "updated_at": "2026-03-05T12:42:43.503336+00:00"
+        }
+      ]
+    },
+    {
+      "id": "phase-3-solver",
+      "name": "Solver Integration",
+      "type": "implementation",
+      "description": "Wire flow variables into the solver: create f[ic,t] continuous variables, integrate new constraints via _add_all_constraints(), extract flow results in _extract_solution(), and add a two-region integration test verifying the full solve pipeline with interconnections.",
+      "depends_on": [
+        "phase-2-constraints"
+      ],
+      "parallel_safe": false,
+      "subtasks": [
+        {
+          "id": "subtask-3-1",
+          "description": "Modify src/uc/solver.py to create flow variables and wire constraints. In solve_uc(): (1) If params.interconnections is non-empty, create f = pulp.LpVariable.dicts('f', ic_indices, lowBound=None, cat='Continuous') where ic_indices = [(ic.id, t) for ic in interconnections for t in timesteps]. (2) Modify _add_all_constraints() to accept interconnections and f; when interconnections present, call add_nodal_balance_constraints() INSTEAD of add_demand_balance_constraints(), plus add_transmission_capacity_constraints(). When no interconnections, call add_demand_balance_constraints() as before. (3) Pass regional_demand dict to nodal balance - compute from params.demand by splitting proportionally by region capacity (reuse _split_demand_by_capacity pattern from decomposition.py, or accept regional_demand as UCParameters field).",
+          "service": "main",
+          "files_to_modify": [
+            "src/uc/solver.py"
+          ],
+          "files_to_create": [],
+          "patterns_from": [
+            "src/uc/solver.py",
+            "src/uc/decomposition.py"
+          ],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -c \"from src.uc.solver import solve_uc; from src.uc.models import UCParameters; print('solver import OK')\"",
+            "expected": "solver import OK"
+          },
+          "status": "completed",
+          "notes": "Modified src/uc/solver.py to create flow variables and wire interconnection constraints. In solve_uc(): (1) When params.interconnections is non-empty, creates f = pulp.LpVariable.dicts('f', ic_indices, lowBound=None, cat='Continuous') for all interconnection-timestep pairs. (2) Modified _add_all_constraints() to accept interconnections and f as optional kwargs; when interconnections present, calls add_nodal_balance_constraints() INSTEAD of add_demand_balance_constraints(), plus add_transmission_capacity_constraints(). When no interconnections, calls add_demand_balance_constraints() as before (backward compatible). (3) Added _split_demand_by_region() helper to compute regional_demand by splitting proportionally by region capacity, reusing the pattern from decomposition.py's _split_demand_by_capacity. All 47 existing solver tests, 34 interconnection tests, and 53 decomposition tests pass unchanged. Committed as 3293352.",
+          "updated_at": "2026-03-05T12:46:16.583651+00:00"
+        },
+        {
+          "id": "subtask-3-2",
+          "description": "Add flow result extraction to solver.py _extract_solution(). When interconnections present: iterate f[ic,t] variables, extract float values, create InterconnectionFlow objects for each interconnection, and add to result.interconnection_flows. Log summary of flow results (max flow, which interconnections are saturated). Also update src/uc/__init__.py exports if not already done.",
+          "service": "main",
+          "files_to_modify": [
+            "src/uc/solver.py"
+          ],
+          "files_to_create": [],
+          "patterns_from": [
+            "src/uc/solver.py"
+          ],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -c \"from src.uc.solver import solve_uc; print('OK')\"",
+            "expected": "OK"
+          },
+          "status": "completed",
+          "notes": "Added flow result extraction to solver.py _extract_solution(). Imported InterconnectionFlow from models. Added interconnections and f as optional keyword parameters to _extract_solution(). When interconnections present: iterates f[ic,t] variables, extracts float values with round(,6), creates InterconnectionFlow objects for each interconnection, and adds to result.interconnection_flows. Logs per-interconnection summary (max flow, capacity, SATURATED flag for >99.9% utilization). Updated solve_uc() call site to pass interconnections=interconnections, f=f. src/uc/__init__.py already exports InterconnectionFlow (no changes needed). All 387 tests pass with no regressions. Committed as 39a2111.",
+          "updated_at": "2026-03-05T12:49:27.648306+00:00"
+        },
+        {
+          "id": "subtask-3-3",
+          "description": "Add two-region integration test to tests/test_uc_interconnection.py: test_two_region_with_interconnection. Create 2 generators in 'tokyo' (300 MW each) and 1 generator in 'chubu' (200 MW). Set tokyo demand=500 MW, chubu demand=250 MW (chubu has shortfall). Add 1 interconnection tokyo->chubu with capacity 100 MW. Solve and verify: (1) Optimal status, (2) flow from tokyo to chubu (positive f value), (3) flow <= 100 MW capacity bound, (4) both regional demands met. Also add test_solve_without_interconnections_unchanged: verify solve_uc with no interconnections produces identical results to current behavior (regression).",
+          "service": "main",
+          "files_to_modify": [
+            "tests/test_uc_interconnection.py"
+          ],
+          "files_to_create": [],
+          "patterns_from": [
+            "tests/test_uc_solver.py"
+          ],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -m pytest tests/test_uc_interconnection.py -v -k 'two_region or without_interconnection' --tb=short 2>&1 | tail -20",
+            "expected": "passed"
+          },
+          "status": "completed",
+          "notes": "Added two integration tests to tests/test_uc_interconnection.py: (1) test_two_region_with_interconnection: creates 2 cheap generators in tokyo (300 MW each, 10 $/MWh) and 1 expensive generator in chubu (200 MW, 100 $/MWh) with a 100 MW interconnection. The proportional demand split (750 MW total → tokyo=562.5, chubu=187.5) creates an economic incentive for the optimizer to export from cheap tokyo to expensive chubu. Verifies: Optimal status, positive flow from tokyo to chubu, flow ≤ 100 MW capacity bound, both regional demands met. (2) test_solve_without_interconnections_unchanged: regression test with 3-generator setup (matching test_uc_solver.py patterns), verifies solve_uc with empty interconnections produces Optimal status, no interconnection flows, demand balance at all timesteps, and cost consistency. All 36 interconnection tests and 126 existing UC tests pass. Committed as 80167b4.",
+          "updated_at": "2026-03-05T12:57:33.462947+00:00"
+        }
+      ]
+    },
+    {
+      "id": "phase-4-decomposition-config",
+      "name": "Decomposition Fallback & Configuration",
+      "type": "implementation",
+      "description": "Add interconnection-aware fallback logic to RegionalDecomposer and the interconnection toggle to uc_config.yaml. When interconnections are present in UCParameters, RegionalDecomposer must return the full national problem as a single partition instead of decomposing by region.",
+      "depends_on": [
+        "phase-3-solver"
+      ],
+      "parallel_safe": true,
+      "subtasks": [
+        {
+          "id": "subtask-4-1",
+          "description": "Modify RegionalDecomposer.partition() in src/uc/decomposition.py. At the top of partition(), add a check: if params.interconnections is non-empty, log an INFO message explaining the fallback ('Interconnections present: bypassing regional decomposition for national MILP') and return [params]. This preserves all existing decomposition behavior when no interconnections are present. Do NOT modify the Decomposer base class or any other decomposer.",
+          "service": "main",
+          "files_to_modify": [
+            "src/uc/decomposition.py"
+          ],
+          "files_to_create": [],
+          "patterns_from": [
+            "src/uc/decomposition.py"
+          ],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -c \"from src.uc.decomposition import RegionalDecomposer; print('Import OK')\"",
+            "expected": "Import OK"
+          },
+          "status": "completed",
+          "notes": "Modified RegionalDecomposer.partition() in src/uc/decomposition.py. Added interconnection check at the top of partition(): when params.interconnections is non-empty, logs INFO message (\"Interconnections present: bypassing regional decomposition for national MILP\") and returns [params]. Preserves all existing decomposition behavior when no interconnections are present. Did NOT modify the Decomposer base class or any other decomposer. All 53 existing decomposition tests pass unchanged. Functional tests verify fallback returns single partition containing the original params. Committed as d5c2c09.",
+          "updated_at": "2026-03-05T12:59:15.270822+00:00"
+        },
+        {
+          "id": "subtask-4-2",
+          "description": "Add interconnection configuration section to config/uc_config.yaml. Add at the end of the file: 'interconnection:' section with 'enabled: false' (default off to preserve existing behavior), 'data_path: data/reference/interconnections.yaml', and 'regional_demand_path: config/regional_demand.yaml'. Document each field with YAML comments explaining usage.",
+          "service": "main",
+          "files_to_modify": [
+            "config/uc_config.yaml"
+          ],
+          "files_to_create": [],
+          "patterns_from": [
+            "config/uc_config.yaml"
+          ],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -c \"import yaml; cfg = yaml.safe_load(open('config/uc_config.yaml')); ic = cfg.get('interconnection', {}); print('enabled:', ic.get('enabled')); print('data_path:', ic.get('data_path')); print('OK')\"",
+            "expected": "OK"
+          },
+          "status": "completed",
+          "notes": "Added interconnection configuration section to config/uc_config.yaml. Added at the end of the file: 'interconnection:' section with 'enabled: false' (default off to preserve existing behavior), 'data_path: data/reference/interconnections.yaml', and 'regional_demand_path: config/regional_demand.yaml'. Each field documented with YAML comments explaining usage. Verified via yaml.safe_load() parsing. Committed as df4e784.",
+          "updated_at": "2026-03-05T13:00:50.136420+00:00"
+        },
+        {
+          "id": "subtask-4-3",
+          "description": "Add decomposition and config tests to tests/test_uc_interconnection.py: (1) test_decomposition_fallback_with_interconnections: create UCParameters with 2-region generators + interconnections, verify RegionalDecomposer.partition() returns [params] (single partition). (2) test_decomposition_without_interconnections_unchanged: verify RegionalDecomposer.partition() still decomposes normally when interconnections list is empty. (3) test_config_toggle_disabled: verify that with interconnection.enabled=false, interconnections are not loaded/used. (4) test_regional_decomposer_solve_with_interconnections: verify solve_decomposed() falls back to national MILP and produces Optimal result.",
+          "service": "main",
+          "files_to_modify": [
+            "tests/test_uc_interconnection.py"
+          ],
+          "files_to_create": [],
+          "patterns_from": [
+            "tests/test_uc_decomposition.py"
+          ],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -m pytest tests/test_uc_interconnection.py -v -k 'decomposition or config' --tb=short 2>&1 | tail -20",
+            "expected": "passed"
+          },
+          "status": "completed",
+          "notes": "Added 12 new tests across 3 test classes to tests/test_uc_interconnection.py: (1) TestDecompositionFallback (5 tests): verify RegionalDecomposer.partition() returns [params] when interconnections present, preserves all generators and interconnections, and still decomposes normally when no interconnections present or when interconnections field defaults to empty. (2) TestConfigToggle (3 tests): verify uc_config.yaml has interconnection.enabled=false by default, data_path points to valid YAML file, and when enabled=true interconnections can be loaded from data_path. (3) TestRegionalDecomposerSolveWithInterconnections (4 tests): verify solve_decomposed() falls back to national MILP producing Optimal result with all generators present, correct schedule lengths, and single partition produces flow results via solve_uc. All 48 tests in test_uc_interconnection.py pass. All 179 existing UC tests pass unchanged (no regressions). Committed as e14c0df.",
+          "updated_at": "2026-03-05T13:04:55.024623+00:00"
+        }
+      ]
+    },
+    {
+      "id": "phase-5-export-regression",
+      "name": "Result Export & Regression Verification",
+      "type": "implementation",
+      "description": "Update the result exporter to include interconnection flow data in XML and CSV output. Run the complete existing test suite to verify no regressions in the 9-constraint UC formulation.",
+      "depends_on": [
+        "phase-4-decomposition-config"
+      ],
+      "parallel_safe": false,
+      "subtasks": [
+        {
+          "id": "subtask-5-1",
+          "description": "Update src/uc/result_exporter.py to include flow data in XML and CSV exports. For XML: add an InterconnectionFlows container element under UCResult with InterconnectionFlow child elements (attributes: interconnection_id, flow values per period). For CSV: add flow rows to a separate section or separate CSV file (interconnection_flows.csv with columns: interconnection_id, period, flow_mw). Only export flow data when interconnection_flows is non-empty.",
+          "service": "main",
+          "files_to_modify": [
+            "src/uc/result_exporter.py"
+          ],
+          "files_to_create": [],
+          "patterns_from": [
+            "src/uc/result_exporter.py"
+          ],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -c \"from src.uc.result_exporter import export_uc_result_xml, export_uc_result_csv; print('Export imports OK')\"",
+            "expected": "Export imports OK"
+          },
+          "status": "completed",
+          "notes": "Updated src/uc/result_exporter.py to include interconnection flow data in XML and CSV exports. For XML: added InterconnectionFlows container element under UCResult with InterconnectionFlow child elements (attributes: interconnection_id) containing FlowPeriod sub-elements (attributes: t, flow_mw). Placed between CostBreakdown and Diagnostics. For CSV: added _export_interconnection_flows_csv() that writes a separate interconnection_flows.csv file (columns: interconnection_id, period, flow_mw) to the same directory as the main CSV. Both exports are conditional on interconnection_flows being non-empty — no output when empty. Imported InterconnectionFlow from models. All 401 tests pass with no regressions. Committed as cd3a60d.",
+          "updated_at": "2026-03-05T13:08:10.663293+00:00"
+        },
+        {
+          "id": "subtask-5-2",
+          "description": "Regression verification: run the complete existing test suite to confirm no regressions. All tests in test_uc_solver.py, test_uc_decomposition.py, test_uc_models.py, and test_uc_xml_loader.py must pass unchanged. Run the full interconnection test suite. Verify: (1) 9 existing constraint builders produce identical results, (2) storage SOC constraints unaffected, (3) decomposition strategies work as before when no interconnections present.",
+          "service": "main",
+          "files_to_modify": [],
+          "files_to_create": [],
+          "patterns_from": [],
+          "verification": {
+            "type": "command",
+            "command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && python -m pytest tests/ -v --tb=short 2>&1 | tail -30",
+            "expected": "passed"
+          },
+          "status": "completed",
+          "notes": "Full regression verification passed. All 401 tests pass (2 skipped, 1 warning unrelated to changes). Breakdown: test_uc_models.py: 79 passed, test_uc_xml_loader.py: 52 passed + 2 skipped, test_uc_solver.py: 47 passed (including 13 storage SOC tests), test_uc_decomposition.py: 53 passed, test_uc_interconnection.py: 48 passed (all new). Verified: (1) 9 existing constraint builders produce identical results (demand balance, capacity bounds, startup/shutdown, min-uptime, min-downtime, ramp rates, maintenance, reserve margin, storage SOC), (2) storage SOC constraints unaffected (pumped hydro and battery tests all pass), (3) decomposition strategies work as before when no interconnections present (regional, fuel-type, time-window all pass).",
+          "updated_at": "2026-03-05T13:15:00.000000+00:00"
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total_phases": 5,
+    "total_subtasks": 14,
+    "services_involved": [
+      "main"
+    ],
+    "parallelism": {
+      "max_parallel_phases": 1,
+      "parallel_groups": [],
+      "recommended_workers": 1,
+      "speedup_estimate": "Sequential execution (single service, tight dependency chain between phases)"
+    },
+    "startup_command": "cd /Users/shigenoburyuto/Documents/GitHub/project_Hayashi/All-Japan-Grid && pip install -r requirements.txt && python -m pytest tests/ -v"
+  },
+  "verification_strategy": {
+    "risk_level": "medium",
+    "skip_validation": false,
+    "test_creation_phase": "per_phase",
+    "test_types_required": [
+      "unit",
+      "integration"
+    ],
+    "security_scanning_required": false,
+    "staging_deployment_required": false,
+    "acceptance_criteria": [
+      "All existing UC tests pass without modification (test_uc_solver.py, test_uc_decomposition.py, test_uc_models.py, test_uc_xml_loader.py)",
+      "InterconnectionLoader loads all 9 OCCTO interconnections from YAML",
+      "Flow variables bounded by +-capacity_mw in all solutions",
+      "Nodal balance satisfied at every region and timestep",
+      "RegionalDecomposer falls back to national MILP when interconnections present",
+      "Config toggle interconnection.enabled=false produces identical results to pre-change behavior",
+      "Two-region integration test solves optimally with correct flow"
+    ],
+    "verification_steps": [
+      {
+        "name": "Existing UC Tests (Regression)",
+        "command": "python -m pytest tests/test_uc_solver.py tests/test_uc_decomposition.py tests/test_uc_models.py tests/test_uc_xml_loader.py -v --tb=short",
+        "expected_outcome": "All tests pass",
+        "type": "test",
+        "required": true,
+        "blocking": true
+      },
+      {
+        "name": "New Interconnection Tests",
+        "command": "python -m pytest tests/test_uc_interconnection.py -v --tb=short",
+        "expected_outcome": "All tests pass",
+        "type": "test",
+        "required": true,
+        "blocking": true
+      },
+      {
+        "name": "Full Test Suite",
+        "command": "python -m pytest tests/ -v --tb=short",
+        "expected_outcome": "All tests pass, no regressions",
+        "type": "test",
+        "required": true,
+        "blocking": true
+      }
+    ],
+    "reasoning": "Medium risk due to modification of core solver constraint logic. The biggest risk is in the demand balance constraint switch (system-wide vs nodal) and ensuring existing behavior is preserved when interconnections are disabled. Unit tests for each new constraint builder plus integration tests for the full solve pipeline provide adequate coverage."
+  },
+  "qa_acceptance": {
+    "unit_tests": {
+      "required": true,
+      "commands": [
+        "python -m pytest tests/test_uc_interconnection.py -v"
+      ],
+      "minimum_coverage": null
+    },
+    "integration_tests": {
+      "required": true,
+      "commands": [
+        "python -m pytest tests/test_uc_interconnection.py -v -k 'two_region or decomposition'"
+      ],
+      "services_to_test": [
+        "main"
+      ]
+    },
+    "e2e_tests": {
+      "required": false,
+      "commands": [],
+      "flows": []
+    },
+    "browser_verification": {
+      "required": false,
+      "pages": []
+    },
+    "database_verification": {
+      "required": false,
+      "checks": []
+    }
+  },
+  "qa_signoff": null,
+  "status": "human_review",
+  "planStatus": "review",
+  "xstateState": "human_review",
+  "executionPhase": "complete",
+  "updated_at": "2026-03-05T13:10:47.812Z",
+  "lastEvent": {
+    "eventId": "cbcb4119-c51f-439d-8d8e-fbc4ce82f636",
+    "sequence": 0,
+    "type": "PLANNING_COMPLETE",
+    "timestamp": "2026-03-05T12:26:52.254462+00:00"
+  },
+  "last_updated": "2026-03-05T13:08:10.663298+00:00",
+  "reviewReason": "completed"
+}

--- a/config/uc_config.yaml
+++ b/config/uc_config.yaml
@@ -103,3 +103,16 @@ defaults:
       initial_soc_fraction: 0.5
       min_terminal_soc_fraction: 0.2
       storage_capacity_mwh: 200
+
+# Inter-regional transmission interconnection constraints
+# When enabled, the solver adds transmission capacity limits between adjacent
+# grid regions (e.g., hokkaido-tohoku, tohoku-tokyo, etc.) to model realistic
+# power flow bottlenecks across the Japanese electricity system.
+# enabled: set to true to activate interconnection constraints in the UC solver
+#   (default false preserves existing single-region behavior)
+# data_path: path to YAML file defining interconnection capacities (MW) per link
+# regional_demand_path: path to YAML file mapping regional demand profiles
+interconnection:
+  enabled: false
+  data_path: data/reference/interconnections.yaml
+  regional_demand_path: config/regional_demand.yaml

--- a/examples/uc_national_interconnection.py
+++ b/examples/uc_national_interconnection.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""National UC with interconnection constraints — 757 real generators.
+
+Loads real power plant data from ``data/{region}_plants.geojson`` (OSM-derived),
+applies UC cost defaults, and solves three scenarios:
+
+1. **Per-region UC** — each of the 10 areas solved independently
+2. **All-Japan copper plate** — 757 generators in a single MILP, no transmission limits
+3. **All-Japan with interconnections** — 757 generators + 9 inter-regional links
+   with nodal balance per region and transmission capacity constraints
+
+The comparison between scenarios (2) and (3) quantifies the cost of transmission
+congestion across the national grid.
+
+Usage::
+
+    python examples/uc_national_interconnection.py
+
+Requirements:
+    - ``data/{region}_plants.geojson`` files (from OSM fetch pipeline)
+    - ``data/reference/interconnections.yaml`` (OCCTO interconnection data)
+    - PuLP with HiGHS or CBC solver
+"""
+
+import json
+import os
+import sys
+import time as _time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+
+from src.model.generator import Generator
+from src.uc.interconnection_loader import InterconnectionLoader
+from src.uc.models import DemandProfile, TimeHorizon, UCParameters
+from src.uc.solver import solve_uc
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+PROJ_ROOT = os.path.join(os.path.dirname(__file__), "..")
+
+NUM_PERIODS = 24
+DEMAND_FACTOR = 0.65         # Peak demand as fraction of installed capacity
+RESERVE_MARGIN = 0.05        # 5% spinning reserve
+MIN_CAPACITY_MW = 5.0        # Generator inclusion threshold
+SOLVER_TIME_LIMIT_S = 600    # 10 minutes max per solve
+MIP_GAP = 0.01               # 1% optimality gap
+
+REGIONS = [
+    "hokkaido", "tohoku", "tokyo", "chubu", "hokuriku",
+    "kansai", "chugoku", "shikoku", "kyushu", "okinawa",
+]
+
+# Summer weekday demand shape (normalized, peak = 1.0)
+DEMAND_SHAPE = np.array([
+    0.60, 0.57, 0.55, 0.53, 0.55, 0.60,   # 00-05h: nighttime
+    0.68, 0.78, 0.87, 0.93, 0.97, 1.00,   # 06-11h: morning ramp
+    0.99, 0.98, 0.96, 0.93, 0.90, 0.86,   # 12-17h: afternoon
+    0.82, 0.78, 0.74, 0.70, 0.66, 0.63,   # 18-23h: evening
+])
+
+# Fuel type cost mapping (¥/MWh)
+FUEL_COST = {
+    "coal": 4500, "gas": 7000, "lng": 7000, "oil": 9000,
+    "nuclear": 1500, "hydro": 0, "wind": 0, "solar": 0,
+    "biomass": 3000, "geothermal": 0, "waste": 5000,
+}
+
+# Normalize OSM fuel types to model fuel types
+FUEL_MAP = {
+    "coal": "coal", "gas": "lng", "lng": "lng", "oil": "oil",
+    "nuclear": "nuclear", "hydro": "hydro", "wind": "wind",
+    "solar": "solar", "biomass": "biomass", "geothermal": "geothermal",
+    "waste": "biomass",
+}
+
+
+# ── Data Loading ──────────────────────────────────────────────────────────────
+
+def load_generators_from_geojson(region):
+    """Load generators from a region's GeoJSON and apply UC cost defaults."""
+    path = os.path.join(PROJ_ROOT, "data", f"{region}_plants.geojson")
+    with open(path) as f:
+        data = json.load(f)
+
+    generators = []
+    for i, feat in enumerate(data["features"]):
+        props = feat["properties"]
+        cap = props.get("capacity_mw")
+        if not cap or float(cap) < MIN_CAPACITY_MW:
+            continue
+
+        cap = float(cap)
+        name = props.get("name") or props.get("_display_name") or f"{region}_gen_{i}"
+        raw_fuel = (props.get("fuel_type") or props.get("plant:source") or "unknown").lower()
+        fuel = FUEL_MAP.get(raw_fuel, "mixed")
+        cost = FUEL_COST.get(raw_fuel, 5000)
+        osm_id = props.get("osm_id", i)
+
+        is_renewable = fuel in ("hydro", "wind", "solar", "geothermal")
+        gen = Generator(
+            id=f"{region}_gen_{osm_id}",
+            name=name,
+            capacity_mw=cap,
+            fuel_type=fuel,
+            region=region,
+            startup_cost=0 if is_renewable else 5000,
+            shutdown_cost=0 if is_renewable else 2000,
+            min_up_time_h=4 if fuel in ("coal", "nuclear") else 2,
+            min_down_time_h=4 if fuel in ("coal", "nuclear") else 2,
+            fuel_cost_per_mwh=cost,
+            no_load_cost=0 if fuel in ("wind", "solar") else 500,
+            labor_cost_per_h=300,
+        )
+        generators.append(gen)
+
+    return generators
+
+
+def load_all_generators():
+    """Load generators from all 10 regions."""
+    region_gens = {}
+    all_gens = []
+    for region in REGIONS:
+        gens = load_generators_from_geojson(region)
+        region_gens[region] = gens
+        all_gens.extend(gens)
+    return region_gens, all_gens
+
+
+def make_demand(total_cap):
+    """Generate a 24h demand profile scaled to installed capacity."""
+    return (DEMAND_SHAPE * total_cap * DEMAND_FACTOR).tolist()
+
+
+# ── UC Solve Helpers ──────────────────────────────────────────────────────────
+
+def solve_region(gens):
+    """Solve UC for a single region."""
+    total_cap = sum(g.capacity_mw for g in gens)
+    demand = make_demand(total_cap)
+    params = UCParameters(
+        generators=gens,
+        demand=DemandProfile(demands=demand),
+        time_horizon=TimeHorizon(num_periods=NUM_PERIODS, period_duration_h=1.0),
+        reserve_margin=RESERVE_MARGIN,
+        solver_time_limit_s=120,
+        mip_gap=MIP_GAP,
+    )
+    return solve_uc(params), total_cap, max(demand)
+
+
+def solve_national(all_gens, interconnections=None):
+    """Solve UC for all generators nationally.
+
+    Args:
+        all_gens: List of all generators across all regions.
+        interconnections: If provided, enables nodal balance per region
+            with transmission capacity constraints. If None, uses a single
+            system-wide demand balance (copper plate model).
+    """
+    total_cap = sum(g.capacity_mw for g in all_gens)
+    demand = make_demand(total_cap)
+    params = UCParameters(
+        generators=all_gens,
+        demand=DemandProfile(demands=demand),
+        time_horizon=TimeHorizon(num_periods=NUM_PERIODS, period_duration_h=1.0),
+        reserve_margin=RESERVE_MARGIN,
+        solver_time_limit_s=SOLVER_TIME_LIMIT_S,
+        mip_gap=MIP_GAP,
+        interconnections=interconnections or [],
+    )
+    return solve_uc(params), total_cap, max(demand)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    wall_start = _time.monotonic()
+
+    print("=" * 80)
+    print("National UC with Interconnection Constraints")
+    print(f"  Generators >= {MIN_CAPACITY_MW} MW | {NUM_PERIODS}h horizon | "
+          f"{RESERVE_MARGIN*100:.0f}% reserve | MIP gap {MIP_GAP*100:.0f}%")
+    print("=" * 80)
+
+    # ── Step 1: Load data ─────────────────────────────────────────────────
+    region_gens, all_gens = load_all_generators()
+    total_cap = sum(g.capacity_mw for g in all_gens)
+
+    print(f"\nLoaded {len(all_gens)} generators, {total_cap:,.0f} MW across {len(REGIONS)} regions\n")
+
+    # ── Step 2: Per-region UC ─────────────────────────────────────────────
+    print("─── (1) Per-Region UC ──────────────────────────────────────────────")
+    print(f"\n{'Region':<12} {'Gens':>5} {'Cap(MW)':>10} {'Peak(MW)':>10} "
+          f"{'Status':<12} {'Cost':>16} {'Time(s)':>8}")
+    print("-" * 82)
+
+    all_ok = True
+    for region in REGIONS:
+        gens = region_gens[region]
+        if not gens:
+            print(f"{region:<12}   N/A — no generators above threshold")
+            continue
+
+        result, cap, peak = solve_region(gens)
+        cost_str = f"¥{result.total_cost:,.0f}" if result.is_optimal else "-"
+        print(f"{region:<12} {len(gens):>5} {cap:>10,.0f} {peak:>10,.0f} "
+              f"{result.status:<12} {cost_str:>16} {result.solve_time_s:>8.2f}")
+
+        if not result.is_optimal:
+            all_ok = False
+            for w in result.warnings[:3]:
+                print(f"  WARNING: {w}")
+
+    # ── Step 3: All-Japan copper plate ────────────────────────────────────
+    print("\n─── (2) All-Japan UC — Copper Plate (no transmission limits) ────────")
+
+    demand = make_demand(total_cap)
+    print(f"\n  Generators: {len(all_gens)} | Capacity: {total_cap:,.0f} MW | "
+          f"Peak demand: {max(demand):,.0f} MW")
+    print("  Solving...")
+
+    result_cp, _, _ = solve_national(all_gens)
+
+    print(f"\n  Status:     {result_cp.status}")
+    print(f"  Cost:       ¥{result_cp.total_cost:,.0f}")
+    print(f"  Solve time: {result_cp.solve_time_s:.2f}s")
+
+    if result_cp.warnings:
+        for w in result_cp.warnings[:3]:
+            print(f"  WARNING: {w}")
+    if not result_cp.is_optimal:
+        all_ok = False
+
+    # ── Step 4: All-Japan with interconnections ───────────────────────────
+    print("\n─── (3) All-Japan UC — With Interconnection Constraints ─────────────")
+
+    ic_path = os.path.join(PROJ_ROOT, "data", "reference", "interconnections.yaml")
+    loader = InterconnectionLoader()
+    interconnections = loader.load(ic_path)
+
+    print(f"\n  Generators: {len(all_gens)} | Interconnections: {len(interconnections)} | "
+          f"Peak demand: {max(demand):,.0f} MW")
+    print("  Solving...")
+
+    result_ic, _, _ = solve_national(all_gens, interconnections)
+
+    print(f"\n  Status:     {result_ic.status}")
+    print(f"  Cost:       ¥{result_ic.total_cost:,.0f}")
+    print(f"  Solve time: {result_ic.solve_time_s:.2f}s")
+
+    if result_ic.warnings:
+        for w in result_ic.warnings[:3]:
+            print(f"  WARNING: {w}")
+    if not result_ic.is_optimal:
+        all_ok = False
+
+    if result_ic.interconnection_flows:
+        print(f"\n  {'Interconnection':<42} {'Max Flow':>10} {'Capacity':>10} {'Util':>6}")
+        print("  " + "-" * 72)
+        for ic in interconnections:
+            flow = next((f for f in result_ic.interconnection_flows
+                         if f.interconnection_id == ic.id), None)
+            if flow:
+                max_flow = max(abs(v) for v in flow.flow_mw)
+                util = max_flow / ic.capacity_mw * 100
+                sat = " SAT" if max_flow >= ic.capacity_mw * 0.999 else ""
+                print(f"  {ic.name_en:<42} {max_flow:>8,.0f} MW {ic.capacity_mw:>8,.0f} MW"
+                      f" {util:>5.1f}%{sat}")
+
+    # ── Step 5: Comparison ────────────────────────────────────────────────
+    print("\n─── Comparison ─────────────────────────────────────────────────────")
+    if result_cp.is_optimal and result_ic.is_optimal:
+        delta = result_ic.total_cost - result_cp.total_cost
+        pct = delta / result_cp.total_cost * 100 if result_cp.total_cost > 0 else 0
+        print(f"  Copper plate:       ¥{result_cp.total_cost:>16,.0f}  ({result_cp.solve_time_s:.1f}s)")
+        print(f"  With IC constraints: ¥{result_ic.total_cost:>15,.0f}  ({result_ic.solve_time_s:.1f}s)")
+        print(f"  Congestion cost:    ¥{delta:>16,.0f}  ({pct:+.2f}%)")
+
+    wall_elapsed = _time.monotonic() - wall_start
+
+    # ── Summary ───────────────────────────────────────────────────────────
+    print("\n" + "=" * 80)
+    if all_ok:
+        print(f"ALL SCENARIOS OPTIMAL — {len(all_gens)} generators feasible across all tests")
+        print(f"  Per-region (×{len(REGIONS)}) + All-Japan copper plate + All-Japan with IC")
+    else:
+        print("SOME SCENARIOS FAILED — check warnings above")
+    print(f"Total wall time: {wall_elapsed:.1f}s")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/output/uc_national_interconnection_result.txt
+++ b/output/uc_national_interconnection_result.txt
@@ -1,0 +1,62 @@
+================================================================================
+National UC with Interconnection Constraints
+  Generators >= 5.0 MW | 24h horizon | 5% reserve | MIP gap 1%
+================================================================================
+
+Loaded 757 generators, 274,408 MW across 10 regions
+
+─── (1) Per-Region UC ──────────────────────────────────────────────
+
+Region        Gens    Cap(MW)   Peak(MW) Status                   Cost  Time(s)
+----------------------------------------------------------------------------------
+hokkaido        72     10,713      6,963 Optimal          ¥113,387,766     0.72
+tohoku         130     39,826     25,887 Optimal          ¥807,808,608     1.91
+tokyo          175     67,404     43,813 Optimal        ¥2,897,293,789     2.42
+chubu          128     43,361     28,185 Optimal          ¥909,466,025     0.99
+hokuriku        32      7,860      5,109 Optimal           ¥43,397,355     0.27
+kansai          56     42,285     27,485 Optimal        ¥1,295,034,561     0.44
+chugoku         42     20,448     13,291 Optimal          ¥954,347,932     0.55
+shikoku         26     12,698      8,253 Optimal          ¥527,177,254     0.24
+kyushu          91     28,306     18,399 Optimal          ¥573,033,280     1.15
+okinawa          5      1,507        980 Optimal           ¥95,584,969     0.07
+
+─── (2) All-Japan UC — Copper Plate (no transmission limits) ────────
+
+  Generators: 757 | Capacity: 274,408 MW | Peak demand: 178,365 MW
+  Solving...
+
+  Status:     Optimal
+  Cost:       ¥7,650,669,856
+  Solve time: 9.28s
+
+─── (3) All-Japan UC — With Interconnection Constraints ─────────────
+
+  Generators: 757 | Interconnections: 9 | Peak demand: 178,365 MW
+  Solving...
+
+  Status:     Optimal
+  Cost:       ¥7,757,731,923
+  Solve time: 8.72s
+
+  Interconnection                              Max Flow   Capacity   Util
+  ------------------------------------------------------------------------
+  Hokkaido-Honshu HVDC Link                       900 MW      900 MW 100.0% SAT
+  Tohoku-Tokyo Interconnection                  5,550 MW    5,550 MW 100.0% SAT
+  Tokyo-Chubu FC Interconnection                2,100 MW    2,100 MW 100.0% SAT
+  Chubu-Kansai Interconnection                  2,530 MW    2,530 MW 100.0% SAT
+  Chubu-Hokuriku Interconnection                1,900 MW    1,900 MW 100.0% SAT
+  Kansai-Chugoku Interconnection                4,090 MW    4,090 MW 100.0% SAT
+  Kansai-Shikoku Interconnection                1,400 MW    1,400 MW 100.0% SAT
+  Chugoku-Shikoku Interconnection               1,200 MW    1,200 MW 100.0% SAT
+  Kanmon Interconnection (Chugoku-Kyushu)       2,780 MW    2,780 MW 100.0% SAT
+
+─── Comparison ─────────────────────────────────────────────────────
+  Copper plate:       ¥   7,650,669,856  (9.3s)
+  With IC constraints: ¥  7,757,731,923  (8.7s)
+  Congestion cost:    ¥     107,062,067  (+1.40%)
+
+================================================================================
+ALL SCENARIOS OPTIMAL — 757 generators feasible across all tests
+  Per-region (×10) + All-Japan copper plate + All-Japan with IC
+Total wall time: 29.3s
+================================================================================

--- a/src/uc/__init__.py
+++ b/src/uc/__init__.py
@@ -7,6 +7,8 @@ generator unit commitment optimisation over configurable time horizons.
 from src.uc.models import (
     DemandProfile,
     GeneratorSchedule,
+    Interconnection,
+    InterconnectionFlow,
     TimeHorizon,
     UCParameters,
     UCResult,
@@ -15,6 +17,8 @@ from src.uc.models import (
 __all__ = [
     "DemandProfile",
     "GeneratorSchedule",
+    "Interconnection",
+    "InterconnectionFlow",
     "TimeHorizon",
     "UCParameters",
     "UCResult",

--- a/src/uc/constraints.py
+++ b/src/uc/constraints.py
@@ -18,6 +18,7 @@ Usage::
         add_maintenance_constraints,
         add_reserve_margin_constraints,
         add_storage_soc_constraints,
+        add_transmission_capacity_constraints,
     )
 
     model = pulp.LpProblem("UC", pulp.LpMinimize)
@@ -32,6 +33,7 @@ from typing import Dict, List, Tuple
 import pulp
 
 from src.model.generator import Generator
+from src.uc.models import Interconnection
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -641,5 +643,55 @@ def add_storage_soc_constraints(
         count,
         n_storage,
         n_skipped,
+    )
+    return count
+
+
+def add_transmission_capacity_constraints(
+    model: pulp.LpProblem,
+    f: Dict[Tuple[str, int], pulp.LpVariable],
+    interconnections: List[Interconnection],
+    timesteps: List[int],
+) -> int:
+    """Add transmission capacity constraints for interconnections.
+
+    Limits the power flow on each interconnection to its rated capacity
+    in both directions:
+
+        ``f[ic,t] <= capacity_mw[ic]``   (upper bound)
+        ``f[ic,t] >= -capacity_mw[ic]``  (lower bound)
+
+    Positive flow represents power transfer from ``from_region`` to
+    ``to_region``; negative flow represents the reverse direction.
+
+    Args:
+        model: PuLP model to add constraints to.
+        f: Flow variables indexed by ``(interconnection_id, timestep)``.
+        interconnections: List of interconnections to constrain.
+        timesteps: List of time period indices.
+
+    Returns:
+        Number of constraints added.
+    """
+    count = 0
+    for ic in interconnections:
+        for t in timesteps:
+            # Upper bound: f <= capacity
+            model += (
+                f[(ic.id, t)] <= ic.capacity_mw,
+                f"tx_cap_ub_{ic.id}_t{t}",
+            )
+            count += 1
+            # Lower bound: f >= -capacity
+            model += (
+                f[(ic.id, t)] >= -ic.capacity_mw,
+                f"tx_cap_lb_{ic.id}_t{t}",
+            )
+            count += 1
+    logger.info(
+        "Added %d transmission capacity constraints (%d interconnections × %d timesteps × 2)",
+        count,
+        len(interconnections),
+        len(timesteps),
     )
     return count

--- a/src/uc/constraints.py
+++ b/src/uc/constraints.py
@@ -19,6 +19,7 @@ Usage::
         add_reserve_margin_constraints,
         add_storage_soc_constraints,
         add_transmission_capacity_constraints,
+        add_nodal_balance_constraints,
     )
 
     model = pulp.LpProblem("UC", pulp.LpMinimize)
@@ -692,6 +693,77 @@ def add_transmission_capacity_constraints(
         "Added %d transmission capacity constraints (%d interconnections × %d timesteps × 2)",
         count,
         len(interconnections),
+        len(timesteps),
+    )
+    return count
+
+
+def add_nodal_balance_constraints(
+    model: pulp.LpProblem,
+    p: Dict[Tuple[str, int], pulp.LpVariable],
+    f: Dict[Tuple[str, int], pulp.LpVariable],
+    generators: List[Generator],
+    interconnections: List[Interconnection],
+    timesteps: List[int],
+    regional_demand: Dict[str, List[float]],
+) -> int:
+    """Add nodal (per-region) power balance constraints.
+
+    Ensures that generation plus net imports meets or exceeds demand in
+    each region at every time step:
+
+        ``Σ_{g∈r} p[g,t] + Σ_{ic: to=r} f[ic,t]
+        - Σ_{ic: from=r} f[ic,t] >= demand[r][idx]``  for all *r*, *t*
+
+    Positive flow on an interconnection represents power transfer from
+    ``from_region`` to ``to_region``.
+
+    Args:
+        model: PuLP model to add constraints to.
+        p: Power output variables indexed by ``(generator_id, timestep)``.
+        f: Flow variables indexed by ``(interconnection_id, timestep)``.
+        generators: List of generators available for commitment.
+        interconnections: List of inter-regional interconnections.
+        timesteps: List of time period indices.
+        regional_demand: Mapping of region identifier to demand series
+            (MW) aligned with *timesteps*.
+
+    Returns:
+        Number of constraints added.
+    """
+    # Group generator IDs by region
+    region_gen_ids: Dict[str, List[str]] = {}
+    for g in generators:
+        region_gen_ids.setdefault(g.region, []).append(g.id)
+
+    # Group interconnections by to_region and from_region
+    ic_to_region: Dict[str, List[Interconnection]] = {}
+    ic_from_region: Dict[str, List[Interconnection]] = {}
+    for ic in interconnections:
+        ic_to_region.setdefault(ic.to_region, []).append(ic)
+        ic_from_region.setdefault(ic.from_region, []).append(ic)
+
+    count = 0
+    for region, demands in regional_demand.items():
+        gen_ids = region_gen_ids.get(region, [])
+        inflows = ic_to_region.get(region, [])
+        outflows = ic_from_region.get(region, [])
+
+        for idx, t in enumerate(timesteps):
+            generation = pulp.lpSum(p[(g_id, t)] for g_id in gen_ids)
+            imports = pulp.lpSum(f[(ic.id, t)] for ic in inflows)
+            exports = pulp.lpSum(f[(ic.id, t)] for ic in outflows)
+
+            model += (
+                generation + imports - exports >= demands[idx],
+                f"nodal_bal_{region}_t{t}",
+            )
+            count += 1
+
+    logger.info(
+        "Added %d nodal balance constraints (%d regions × %d timesteps)",
+        count,
+        len(regional_demand),
         len(timesteps),
     )
     return count

--- a/src/uc/decomposition.py
+++ b/src/uc/decomposition.py
@@ -269,8 +269,20 @@ class RegionalDecomposer(Decomposer):
         Returns:
             One UCParameters per region with proportional demand.
             Returns ``[params]`` if all generators share the same
-            region or the generator list is empty.
+            region, the generator list is empty, or interconnections
+            are present (national MILP fallback).
         """
+        # When interconnections are present, regional decomposition would
+        # break the inter-region coupling constraints.  Fall back to a
+        # single national MILP so that nodal balance and transmission
+        # capacity constraints are handled correctly.
+        if params.interconnections:
+            logger.info(
+                "RegionalDecomposer: Interconnections present: bypassing "
+                "regional decomposition for national MILP"
+            )
+            return [params]
+
         if not params.generators:
             logger.warning("RegionalDecomposer: no generators to partition")
             return []

--- a/src/uc/interconnection_loader.py
+++ b/src/uc/interconnection_loader.py
@@ -1,0 +1,90 @@
+"""Load interconnection data from YAML into UC-ready format.
+
+Reads inter-regional interconnection definitions from a YAML file
+(``data/reference/interconnections.yaml``), validates required fields,
+and produces a list of :class:`~src.uc.models.Interconnection` objects
+for use in unit commitment solving with transmission capacity constraints.
+
+Usage::
+
+    from src.uc.interconnection_loader import InterconnectionLoader
+
+    loader = InterconnectionLoader()
+    interconnections = loader.load("data/reference/interconnections.yaml")
+"""
+
+from typing import List
+
+import yaml
+
+from src.uc.models import Interconnection
+from src.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Required fields in each interconnection record
+_REQUIRED_FIELDS = ("id", "from_region", "to_region", "capacity_mw")
+
+
+class InterconnectionLoader:
+    """Load interconnection data from YAML.
+
+    Reads interconnection records from a YAML file, validates that all
+    required fields are present, and returns a list of
+    :class:`Interconnection` instances.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the InterconnectionLoader."""
+        logger.info("InterconnectionLoader initialized")
+
+    def load(self, yaml_path: str) -> List[Interconnection]:
+        """Load interconnection definitions from a YAML file.
+
+        Reads the ``interconnections`` key from the YAML document and
+        creates an :class:`Interconnection` for each record. Validates
+        that all required fields (``id``, ``from_region``, ``to_region``,
+        ``capacity_mw``) are present in each record.
+
+        Args:
+            yaml_path: Path to the interconnections YAML file.
+
+        Returns:
+            List of :class:`Interconnection` objects.
+
+        Raises:
+            FileNotFoundError: If *yaml_path* does not exist.
+            ValueError: If a required field is missing from any record.
+        """
+        logger.info("Loading interconnections from YAML: %s", yaml_path)
+
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+
+        interconnections: List[Interconnection] = []
+
+        for idx, record in enumerate(data.get("interconnections", [])):
+            # Validate required fields
+            for field_name in _REQUIRED_FIELDS:
+                if field_name not in record:
+                    raise ValueError(
+                        f"Interconnection record {idx} is missing "
+                        f"required field '{field_name}'"
+                    )
+
+            ic = Interconnection(
+                id=record["id"],
+                name_en=record.get("name_en", ""),
+                from_region=record["from_region"],
+                to_region=record["to_region"],
+                capacity_mw=float(record["capacity_mw"]),
+                type=record.get("type", "AC"),
+            )
+            interconnections.append(ic)
+
+        logger.info(
+            "Loaded %d interconnections from %s",
+            len(interconnections),
+            yaml_path,
+        )
+        return interconnections

--- a/src/uc/models.py
+++ b/src/uc/models.py
@@ -97,6 +97,57 @@ class DemandProfile:
 
 
 @dataclass
+class Interconnection:
+    """An inter-regional transmission interconnection.
+
+    Attributes:
+        id: Unique identifier (e.g., ``'ic_001'``).
+        name_en: English name of the interconnection.
+        from_region: Source region identifier.
+        to_region: Destination region identifier.
+        capacity_mw: Maximum transfer capacity in MW.
+        type: Interconnection type (``'AC'``, ``'HVDC'``, ``'FC'``).
+    """
+
+    id: str
+    name_en: str
+    from_region: str
+    to_region: str
+    capacity_mw: float
+    type: str = "AC"
+
+    def __post_init__(self) -> None:
+        """Validate interconnection parameters."""
+        if not self.id:
+            raise ValueError("Interconnection id must not be empty")
+        if self.capacity_mw <= 0:
+            raise ValueError(
+                f"Interconnection capacity_mw must be positive, got {self.capacity_mw}"
+            )
+        if self.from_region == self.to_region:
+            raise ValueError(
+                f"from_region and to_region must differ, both are '{self.from_region}'"
+            )
+
+
+@dataclass
+class InterconnectionFlow:
+    """Flow results for a single interconnection across the planning horizon.
+
+    Positive flow indicates power transfer from ``from_region`` to
+    ``to_region``. Negative flow indicates the reverse direction.
+
+    Attributes:
+        interconnection_id: ID of the interconnection this flow belongs to.
+        flow_mw: Power flow (MW) per period. Positive = from_region to
+            to_region direction.
+    """
+
+    interconnection_id: str = ""
+    flow_mw: List[float] = field(default_factory=list)
+
+
+@dataclass
 class UCParameters:
     """Input parameters for a unit commitment optimisation problem.
 
@@ -113,6 +164,9 @@ class UCParameters:
             ``None`` uses the solver default.
         solver_options: Additional solver-specific options passed through
             to the backend.
+        interconnections: List of inter-regional interconnections for
+            transmission capacity constraints. Empty list disables
+            interconnection modelling.
     """
 
     generators: List[Generator] = field(default_factory=list)
@@ -123,6 +177,7 @@ class UCParameters:
     solver_time_limit_s: Optional[float] = None
     mip_gap: Optional[float] = None
     solver_options: Dict[str, Any] = field(default_factory=dict)
+    interconnections: List[Interconnection] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         """Validate UC parameters."""
@@ -228,6 +283,8 @@ class UCResult:
         solve_time_s: Wall-clock solve time in seconds.
         gap: Relative MIP optimality gap achieved (0.0 = proven optimal).
         warnings: Non-fatal issues encountered during setup or solve.
+        interconnection_flows: Per-interconnection flow results across the
+            planning horizon. Empty when interconnections are not modelled.
     """
 
     status: str = "Not Solved"
@@ -236,6 +293,7 @@ class UCResult:
     solve_time_s: float = 0.0
     gap: Optional[float] = None
     warnings: List[str] = field(default_factory=list)
+    interconnection_flows: List[InterconnectionFlow] = field(default_factory=list)
 
     @property
     def is_optimal(self) -> bool:

--- a/src/uc/result_exporter.py
+++ b/src/uc/result_exporter.py
@@ -26,7 +26,7 @@ from typing import Optional
 
 from lxml import etree
 
-from src.uc.models import GeneratorSchedule, UCResult
+from src.uc.models import GeneratorSchedule, InterconnectionFlow, UCResult
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -208,6 +208,62 @@ def _build_diagnostics_element(result: UCResult) -> Optional[etree._Element]:
     return elem
 
 
+def _build_interconnection_flow_element(
+    flow: InterconnectionFlow,
+) -> etree._Element:
+    """Build an InterconnectionFlow XML element for a single interconnection.
+
+    Includes FlowPeriod sub-elements for each timestep with the flow value
+    in MW.
+
+    Args:
+        flow: InterconnectionFlow dataclass instance with per-period flows.
+
+    Returns:
+        lxml Element representing the InterconnectionFlow.
+    """
+    attrs = {
+        "interconnection_id": flow.interconnection_id,
+    }
+    elem = etree.Element(f"{{{NAMESPACE}}}InterconnectionFlow", **attrs)
+
+    for t, flow_mw in enumerate(flow.flow_mw):
+        period_attrs = {
+            "t": str(t),
+            "flow_mw": _format_decimal(flow_mw),
+        }
+        period_elem = etree.Element(
+            f"{{{NAMESPACE}}}FlowPeriod", **period_attrs
+        )
+        elem.append(period_elem)
+
+    return elem
+
+
+def _build_interconnection_flows_element(
+    result: UCResult,
+) -> Optional[etree._Element]:
+    """Build an InterconnectionFlows container XML element.
+
+    Returns ``None`` if there are no interconnection flows to report.
+
+    Args:
+        result: UCResult with optional interconnection flow data.
+
+    Returns:
+        lxml Element representing InterconnectionFlows, or None if empty.
+    """
+    if not result.interconnection_flows:
+        return None
+
+    elem = etree.Element(f"{{{NAMESPACE}}}InterconnectionFlows")
+    for flow in result.interconnection_flows:
+        flow_elem = _build_interconnection_flow_element(flow)
+        elem.append(flow_elem)
+
+    return elem
+
+
 def export_uc_result_xml(result: UCResult, output_path: str) -> str:
     """Export a UCResult to XML conforming to uc_result.xsd.
 
@@ -269,6 +325,11 @@ def export_uc_result_xml(result: UCResult, output_path: str) -> str:
         cost_elem = _build_cost_breakdown_element(result)
         root.append(cost_elem)
 
+    # InterconnectionFlows (only when flow data is present)
+    flows_elem = _build_interconnection_flows_element(result)
+    if flows_elem is not None:
+        root.append(flows_elem)
+
     # Diagnostics (warnings)
     diag_elem = _build_diagnostics_element(result)
     if diag_elem is not None:
@@ -297,6 +358,63 @@ def export_uc_result_xml(result: UCResult, output_path: str) -> str:
 # ------------------------------------------------------------------
 
 
+def _export_interconnection_flows_csv(
+    result: UCResult, output_path: str
+) -> str:
+    """Export interconnection flow data to a separate CSV file.
+
+    The CSV has the following columns:
+
+    - ``interconnection_id``: Interconnection identifier.
+    - ``period``: Time period index.
+    - ``flow_mw``: Power flow in MW (positive = from_region to to_region).
+
+    Only called when ``result.interconnection_flows`` is non-empty.
+
+    Args:
+        result: UCResult instance with interconnection flow data.
+        output_path: File path for the output CSV.
+
+    Returns:
+        The absolute path to the generated CSV file.
+    """
+    _ensure_output_dir(output_path)
+
+    fieldnames = [
+        "interconnection_id",
+        "period",
+        "flow_mw",
+    ]
+
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        # Header comment with summary info
+        f.write(
+            f"# Interconnection Flows: status={result.status},"
+            f" num_interconnections={len(result.interconnection_flows)}\n"
+        )
+
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for flow in result.interconnection_flows:
+            for t, flow_mw in enumerate(flow.flow_mw):
+                writer.writerow(
+                    {
+                        "interconnection_id": flow.interconnection_id,
+                        "period": t,
+                        "flow_mw": _format_decimal(flow_mw),
+                    }
+                )
+
+    logger.info(
+        "Interconnection flows CSV exported: %d interconnections to %s",
+        len(result.interconnection_flows),
+        output_path,
+    )
+
+    return os.path.abspath(output_path)
+
+
 def export_uc_result_csv(result: UCResult, output_path: str) -> str:
     """Export a UCResult to CSV with one row per (generator, period).
 
@@ -313,6 +431,10 @@ def export_uc_result_csv(result: UCResult, output_path: str) -> str:
     - ``total_cost``: Generator total cost.
 
     A header comment line is included with the solve status and total cost.
+
+    When ``result.interconnection_flows`` is non-empty, a companion CSV file
+    ``interconnection_flows.csv`` is written to the same directory with
+    columns: ``interconnection_id``, ``period``, ``flow_mw``.
 
     Args:
         result: UCResult instance from the solver.
@@ -373,6 +495,14 @@ def export_uc_result_csv(result: UCResult, output_path: str) -> str:
                         "total_cost": _format_decimal(schedule.total_cost),
                     }
                 )
+
+    # Export interconnection flows to a separate CSV when present
+    if result.interconnection_flows:
+        flows_dir = os.path.dirname(output_path)
+        flows_path = os.path.join(
+            flows_dir, "interconnection_flows.csv"
+        ) if flows_dir else "interconnection_flows.csv"
+        _export_interconnection_flows_csv(result, flows_path)
 
     logger.info(
         "UC result CSV exported: %d schedules, total_cost=%.2f",

--- a/src/uc/solver.py
+++ b/src/uc/solver.py
@@ -32,12 +32,19 @@ from src.uc.constraints import (
     add_maintenance_constraints,
     add_min_downtime_constraints,
     add_min_uptime_constraints,
+    add_nodal_balance_constraints,
     add_ramp_constraints,
     add_reserve_margin_constraints,
     add_startup_shutdown_logic,
     add_storage_soc_constraints,
+    add_transmission_capacity_constraints,
 )
-from src.uc.models import GeneratorSchedule, UCParameters, UCResult
+from src.uc.models import (
+    GeneratorSchedule,
+    Interconnection,
+    UCParameters,
+    UCResult,
+)
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -158,6 +165,23 @@ def solve_uc(params: UCParameters) -> UCResult:
         z_ch = {}
         soc = {}
 
+    # Interconnection flow variables
+    interconnections = params.interconnections
+    f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+    if interconnections:
+        ic_indices = [
+            (ic.id, t) for ic in interconnections for t in timesteps
+        ]
+        f = pulp.LpVariable.dicts(
+            "f", ic_indices, lowBound=None, cat="Continuous"
+        )
+        logger.info(
+            "Created %d flow variables (%d interconnections × %d timesteps)",
+            len(ic_indices),
+            len(interconnections),
+            len(timesteps),
+        )
+
     logger.info(
         "Created %d decision variables (%d generators × %d timesteps × 4)",
         len(indices) * 4,
@@ -173,6 +197,7 @@ def solve_uc(params: UCParameters) -> UCResult:
         model, u, p, v, w, generators, timesteps, demand, params.reserve_margin,
         p_ch=p_ch, p_dis=p_dis, z_ch=z_ch, soc=soc,
         period_duration_h=params.time_horizon.period_duration_h,
+        interconnections=interconnections, f=f,
     )
 
     # --- Select and run solver ---------------------------------------------
@@ -281,9 +306,27 @@ def _add_all_constraints(
     z_ch: Optional[Dict[Tuple[str, int], pulp.LpVariable]] = None,
     soc: Optional[Dict[Tuple[str, int], pulp.LpVariable]] = None,
     period_duration_h: float = 1.0,
+    interconnections: Optional[List[Interconnection]] = None,
+    f: Optional[Dict[Tuple[str, int], pulp.LpVariable]] = None,
 ) -> None:
-    """Add all constraint classes to the model."""
-    add_demand_balance_constraints(model, p, generators, timesteps, demand)
+    """Add all constraint classes to the model.
+
+    When interconnections are present, uses per-region nodal balance
+    constraints instead of system-wide demand balance, and adds
+    transmission capacity constraints on flow variables.
+    """
+    if interconnections and f:
+        # Nodal balance replaces system-wide demand balance
+        regional_demand = _split_demand_by_region(generators, demand)
+        add_nodal_balance_constraints(
+            model, p, f, generators, interconnections, timesteps,
+            regional_demand,
+        )
+        add_transmission_capacity_constraints(
+            model, f, interconnections, timesteps,
+        )
+    else:
+        add_demand_balance_constraints(model, p, generators, timesteps, demand)
     add_capacity_bounds_constraints(model, u, p, generators, timesteps)
     add_startup_shutdown_logic(model, u, v, w, generators, timesteps)
     add_min_uptime_constraints(model, u, v, generators, timesteps)
@@ -297,6 +340,45 @@ def _add_all_constraints(
         model, p, p_ch or {}, p_dis or {}, z_ch or {}, soc or {},
         u, generators, timesteps, period_duration_h,
     )
+
+
+def _split_demand_by_region(
+    generators: List[Generator],
+    demand: List[float],
+) -> Dict[str, List[float]]:
+    """Split total demand proportionally by region capacity.
+
+    Each region receives a fraction of total demand proportional to its
+    share of total generation capacity.  Follows the same pattern as
+    ``_split_demand_by_capacity`` in ``decomposition.py``.
+
+    Args:
+        generators: List of generators with ``region`` and
+            ``capacity_mw`` attributes.
+        demand: System-wide demand values (MW) per period.
+
+    Returns:
+        Mapping of region identifier to demand series for that region.
+    """
+    # Group generators by region
+    groups: Dict[str, List[Generator]] = {}
+    for g in generators:
+        key = g.region if g.region else "_unassigned"
+        groups.setdefault(key, []).append(g)
+
+    total_cap = sum(g.capacity_mw for g in generators)
+    if total_cap <= 0:
+        # Equal split if no capacity info
+        n = len(groups) or 1
+        return {key: [d / n for d in demand] for key in groups}
+
+    result: Dict[str, List[float]] = {}
+    for key, gens in groups.items():
+        group_cap = sum(g.capacity_mw for g in gens)
+        fraction = group_cap / total_cap
+        result[key] = [d * fraction for d in demand]
+
+    return result
 
 
 def _select_solver(params: UCParameters) -> pulp.apis.LpSolver:

--- a/src/uc/solver.py
+++ b/src/uc/solver.py
@@ -42,6 +42,7 @@ from src.uc.constraints import (
 from src.uc.models import (
     GeneratorSchedule,
     Interconnection,
+    InterconnectionFlow,
     UCParameters,
     UCResult,
 )
@@ -222,6 +223,7 @@ def solve_uc(params: UCParameters) -> UCResult:
         _extract_solution(
             result, model, u, p, v, w, generators, timesteps,
             p_ch=p_ch, p_dis=p_dis, soc=soc, storage_ids=storage_ids,
+            interconnections=interconnections, f=f,
         )
     elif result.status == "Infeasible":
         _diagnose_infeasibility(result, generators, timesteps, demand)
@@ -439,12 +441,16 @@ def _extract_solution(
     p_dis: Optional[Dict[Tuple[str, int], pulp.LpVariable]] = None,
     soc: Optional[Dict[Tuple[str, int], pulp.LpVariable]] = None,
     storage_ids: Optional[set] = None,
+    interconnections: Optional[List[Interconnection]] = None,
+    f: Optional[Dict[Tuple[str, int], pulp.LpVariable]] = None,
 ) -> None:
     """Extract solution values into GeneratorSchedule objects.
 
     Populates the UCResult with per-generator schedules, cost
     breakdowns, and the total system cost.  For storage generators,
-    also extracts SOC, charge, and discharge profiles.
+    also extracts SOC, charge, and discharge profiles.  For
+    interconnections, extracts per-interconnection flow values and
+    logs saturation summary.
     """
     result.total_cost = pulp.value(model.objective)
 
@@ -518,6 +524,40 @@ def _extract_solution(
             len(timesteps),
             schedule.total_cost,
         )
+
+    # --- Extract interconnection flow results ------------------------------
+    if interconnections and f:
+        saturated_ids = []
+        for ic in interconnections:
+            flow_values = []
+            for t in timesteps:
+                flow_val = float(pulp.value(f[(ic.id, t)]))
+                flow_values.append(round(flow_val, 6))
+
+            ic_flow = InterconnectionFlow(
+                interconnection_id=ic.id,
+                flow_mw=flow_values,
+            )
+            result.interconnection_flows.append(ic_flow)
+
+            max_abs_flow = max(abs(fv) for fv in flow_values) if flow_values else 0.0
+            is_saturated = max_abs_flow >= ic.capacity_mw * 0.999
+            if is_saturated:
+                saturated_ids.append(ic.id)
+
+            logger.info(
+                "Interconnection %s: max_flow=%.1f MW / %.1f MW capacity%s",
+                ic.id,
+                max_abs_flow,
+                ic.capacity_mw,
+                " (SATURATED)" if is_saturated else "",
+            )
+
+        if saturated_ids:
+            logger.info(
+                "Saturated interconnections: %s",
+                ", ".join(saturated_ids),
+            )
 
 
 def _diagnose_infeasibility(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from src.model.substation import (
     VoltageClass,
 )
 from src.model.transmission_line import TransmissionLine
+from src.uc.models import Interconnection
 
 
 # ======================================================================
@@ -490,6 +491,34 @@ def make_storage_generator(
         initial_soc_fraction=initial_soc_fraction,
         min_terminal_soc_fraction=min_terminal_soc_fraction,
         **kwargs,
+    )
+
+
+# ======================================================================
+# Interconnection factory
+# ======================================================================
+
+
+def make_interconnection(
+    id: str = "ic_test_001",
+    name_en: str = "Test Interconnection",
+    from_region: str = "tokyo",
+    to_region: str = "chubu",
+    capacity_mw: float = 1000.0,
+    type: str = "AC",
+) -> Interconnection:
+    """Factory function for creating Interconnection instances in tests.
+
+    Provides sensible defaults for a Tokyo-Chubu AC interconnection
+    while allowing any field to be overridden.
+    """
+    return Interconnection(
+        id=id,
+        name_en=name_en,
+        from_region=from_region,
+        to_region=to_region,
+        capacity_mw=capacity_mw,
+        type=type,
     )
 
 

--- a/tests/test_uc_interconnection.py
+++ b/tests/test_uc_interconnection.py
@@ -9,6 +9,8 @@ Tests cover:
 - Transmission capacity constraint builder (flow bounded by capacity)
 - Nodal balance constraint builder (per-region generation + net flow >= demand)
 - Flow sign convention (positive = from_region -> to_region)
+- Two-region integration test via solve_uc with interconnection flow verification
+- Regression test: solve_uc without interconnections produces unchanged behavior
 """
 
 from pathlib import Path
@@ -23,7 +25,14 @@ from src.uc.constraints import (
     add_transmission_capacity_constraints,
 )
 from src.uc.interconnection_loader import InterconnectionLoader
-from src.uc.models import Interconnection, InterconnectionFlow
+from src.uc.models import (
+    DemandProfile,
+    Interconnection,
+    InterconnectionFlow,
+    TimeHorizon,
+    UCParameters,
+)
+from src.uc.solver import solve_uc
 from tests.conftest import make_generator, make_interconnection
 
 
@@ -780,3 +789,215 @@ class TestPackageExports:
 
         flow = ICFlow(interconnection_id="test", flow_mw=[1.0, 2.0])
         assert flow.interconnection_id == "test"
+
+
+# ======================================================================
+# Helpers — integration tests
+# ======================================================================
+
+
+def _flat_demand(mw: float, periods: int) -> DemandProfile:
+    """Create a constant demand profile."""
+    return DemandProfile(demands=[mw] * periods)
+
+
+# ======================================================================
+# TestTwoRegionIntegration — solve_uc with interconnection
+# ======================================================================
+
+
+class TestTwoRegionIntegration:
+    """Integration tests for solve_uc with interconnections."""
+
+    def test_two_region_with_interconnection(self) -> None:
+        """Two-region solve with interconnection: flow from cheap to expensive region."""
+        # 2 cheap generators in tokyo (300 MW each, total 600 MW)
+        g1 = make_generator(
+            id="g_tokyo_1",
+            name="Tokyo Gen 1",
+            capacity_mw=300.0,
+            region="tokyo",
+            fuel_cost_per_mwh=10.0,
+        )
+        g2 = make_generator(
+            id="g_tokyo_2",
+            name="Tokyo Gen 2",
+            capacity_mw=300.0,
+            region="tokyo",
+            fuel_cost_per_mwh=10.0,
+        )
+        # 1 expensive generator in chubu (200 MW)
+        g3 = make_generator(
+            id="g_chubu_1",
+            name="Chubu Gen 1",
+            capacity_mw=200.0,
+            region="chubu",
+            fuel_cost_per_mwh=100.0,
+        )
+
+        # Interconnection: tokyo -> chubu, 100 MW capacity
+        ic = make_interconnection(
+            id="ic_tokyo_chubu",
+            from_region="tokyo",
+            to_region="chubu",
+            capacity_mw=100.0,
+        )
+
+        th = TimeHorizon(num_periods=4, period_duration_h=1.0)
+        # Total demand 750 MW; proportional split by capacity (600:200):
+        #   tokyo = 750 * 0.75 = 562.5 MW, chubu = 750 * 0.25 = 187.5 MW
+        # Tokyo surplus (600 - 562.5 = 37.5 MW) at 10 $/MWh is cheaper
+        # than chubu at 100 $/MWh, so optimizer exports from tokyo to chubu.
+        dp = _flat_demand(750.0, 4)
+        params = UCParameters(
+            generators=[g1, g2, g3],
+            demand=dp,
+            time_horizon=th,
+            interconnections=[ic],
+        )
+
+        result = solve_uc(params)
+
+        # (1) Optimal status
+        assert result.status == "Optimal"
+        assert result.total_cost > 0
+
+        # (2) Positive flow from tokyo to chubu
+        assert len(result.interconnection_flows) == 1
+        ic_flow = result.interconnection_flows[0]
+        assert ic_flow.interconnection_id == "ic_tokyo_chubu"
+        assert len(ic_flow.flow_mw) == 4
+        for t, flow_val in enumerate(ic_flow.flow_mw):
+            assert flow_val > 0, (
+                f"Expected positive flow at t={t}, got {flow_val}"
+            )
+
+        # (3) Flow <= 100 MW capacity bound
+        for t, flow_val in enumerate(ic_flow.flow_mw):
+            assert flow_val <= 100.0 + 1e-3, (
+                f"Flow at t={t} exceeds capacity: {flow_val}"
+            )
+
+        # (4) Both regional demands met
+        # Proportional split: tokyo = 75%, chubu = 25%
+        tokyo_demand = 750.0 * (600.0 / 800.0)  # 562.5
+        chubu_demand = 750.0 * (200.0 / 800.0)  # 187.5
+        for t in range(4):
+            tokyo_gen = sum(
+                s.power_output_mw[t]
+                for s in result.schedules
+                if s.generator_id.startswith("g_tokyo")
+            )
+            chubu_gen = sum(
+                s.power_output_mw[t]
+                for s in result.schedules
+                if s.generator_id.startswith("g_chubu")
+            )
+            flow = ic_flow.flow_mw[t]
+            # tokyo: generation - export >= demand
+            assert tokyo_gen - flow >= tokyo_demand - 1e-3, (
+                f"Tokyo demand not met at t={t}: gen={tokyo_gen}, "
+                f"export={flow}, demand={tokyo_demand}"
+            )
+            # chubu: generation + import >= demand
+            assert chubu_gen + flow >= chubu_demand - 1e-3, (
+                f"Chubu demand not met at t={t}: gen={chubu_gen}, "
+                f"import={flow}, demand={chubu_demand}"
+            )
+
+
+# ======================================================================
+# TestSolveWithoutInterconnections — regression
+# ======================================================================
+
+
+class TestSolveWithoutInterconnections:
+    """Regression tests: solve_uc without interconnections is unchanged."""
+
+    def test_solve_without_interconnections_unchanged(self) -> None:
+        """solve_uc with no interconnections produces standard optimal result."""
+        # 3-generator setup following test_uc_solver.py pattern
+        g1 = make_generator(
+            id="g1",
+            name="Base Coal",
+            capacity_mw=200.0,
+            fuel_type="coal",
+            p_min_mw=50.0,
+            startup_cost=5000.0,
+            shutdown_cost=2000.0,
+            min_up_time_h=4,
+            min_down_time_h=4,
+            ramp_up_mw_per_h=50.0,
+            ramp_down_mw_per_h=50.0,
+            fuel_cost_per_mwh=30.0,
+            labor_cost_per_h=10.0,
+            no_load_cost=100.0,
+        )
+        g2 = make_generator(
+            id="g2",
+            name="Mid LNG",
+            capacity_mw=150.0,
+            fuel_type="lng",
+            p_min_mw=30.0,
+            startup_cost=2000.0,
+            shutdown_cost=1000.0,
+            min_up_time_h=2,
+            min_down_time_h=2,
+            ramp_up_mw_per_h=75.0,
+            ramp_down_mw_per_h=75.0,
+            fuel_cost_per_mwh=50.0,
+            labor_cost_per_h=8.0,
+            no_load_cost=50.0,
+        )
+        g3 = make_generator(
+            id="g3",
+            name="Peak Oil",
+            capacity_mw=100.0,
+            fuel_type="oil",
+            p_min_mw=10.0,
+            startup_cost=1000.0,
+            shutdown_cost=500.0,
+            min_up_time_h=1,
+            min_down_time_h=1,
+            ramp_up_mw_per_h=100.0,
+            ramp_down_mw_per_h=100.0,
+            fuel_cost_per_mwh=80.0,
+            labor_cost_per_h=5.0,
+            no_load_cost=20.0,
+        )
+
+        th = TimeHorizon(num_periods=24, period_duration_h=1.0)
+        dp = _flat_demand(200.0, 24)
+        params = UCParameters(
+            generators=[g1, g2, g3],
+            demand=dp,
+            time_horizon=th,
+            interconnections=[],  # No interconnections
+        )
+
+        result = solve_uc(params)
+
+        # Status and basic structure
+        assert result.status == "Optimal"
+        assert result.total_cost > 0
+        assert result.solve_time_s >= 0
+        assert len(result.schedules) == 3
+
+        # No interconnection flows in result
+        assert len(result.interconnection_flows) == 0
+
+        # All generators have schedules
+        gen_ids = {s.generator_id for s in result.schedules}
+        assert gen_ids == {"g1", "g2", "g3"}
+
+        # Demand balance holds at every timestep
+        for t in range(24):
+            total_gen = sum(s.power_output_mw[t] for s in result.schedules)
+            assert total_gen >= 200.0 - 1e-3, (
+                f"Demand balance violated at t={t}: "
+                f"generation={total_gen:.4f} < demand=200.0"
+            )
+
+        # Total cost equals sum of generator costs
+        sum_gen_costs = sum(s.total_cost for s in result.schedules)
+        assert abs(result.total_cost - sum_gen_costs) < 1.0

--- a/tests/test_uc_interconnection.py
+++ b/tests/test_uc_interconnection.py
@@ -1,0 +1,223 @@
+"""Tests for interconnection data models and loader.
+
+Tests cover:
+- Interconnection dataclass validation (empty id, negative capacity, same from/to region)
+- InterconnectionLoader loads all 9 records from YAML
+- InterconnectionLoader raises FileNotFoundError for missing file
+- InterconnectionFlow dataclass construction
+- Interconnection and InterconnectionFlow exports from src.uc
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.uc.interconnection_loader import InterconnectionLoader
+from src.uc.models import Interconnection, InterconnectionFlow
+from tests.conftest import make_interconnection
+
+
+# ======================================================================
+# TestInterconnectionDataclass — validation
+# ======================================================================
+
+
+class TestInterconnectionDataclass:
+    """Tests that the Interconnection dataclass validates inputs correctly."""
+
+    def test_valid_interconnection(self) -> None:
+        """A valid Interconnection instance is created without errors."""
+        ic = make_interconnection()
+        assert ic.id == "ic_test_001"
+        assert ic.name_en == "Test Interconnection"
+        assert ic.from_region == "tokyo"
+        assert ic.to_region == "chubu"
+        assert ic.capacity_mw == 1000.0
+        assert ic.type == "AC"
+
+    def test_empty_id_raises_value_error(self) -> None:
+        """Empty id raises ValueError."""
+        with pytest.raises(ValueError, match="id must not be empty"):
+            make_interconnection(id="")
+
+    def test_negative_capacity_raises_value_error(self) -> None:
+        """Negative capacity_mw raises ValueError."""
+        with pytest.raises(ValueError, match="capacity_mw must be positive"):
+            make_interconnection(capacity_mw=-100.0)
+
+    def test_zero_capacity_raises_value_error(self) -> None:
+        """Zero capacity_mw raises ValueError."""
+        with pytest.raises(ValueError, match="capacity_mw must be positive"):
+            make_interconnection(capacity_mw=0.0)
+
+    def test_same_from_to_region_raises_value_error(self) -> None:
+        """Same from_region and to_region raises ValueError."""
+        with pytest.raises(ValueError, match="from_region and to_region must differ"):
+            make_interconnection(from_region="tokyo", to_region="tokyo")
+
+    def test_custom_type_hvdc(self) -> None:
+        """HVDC type is accepted."""
+        ic = make_interconnection(type="HVDC")
+        assert ic.type == "HVDC"
+
+    def test_custom_type_fc(self) -> None:
+        """FC (frequency converter) type is accepted."""
+        ic = make_interconnection(type="FC")
+        assert ic.type == "FC"
+
+    def test_default_type_is_ac(self) -> None:
+        """Default type is AC when not specified."""
+        ic = Interconnection(
+            id="ic_test",
+            name_en="Test",
+            from_region="hokkaido",
+            to_region="tohoku",
+            capacity_mw=500.0,
+        )
+        assert ic.type == "AC"
+
+
+# ======================================================================
+# TestInterconnectionFlow — dataclass construction
+# ======================================================================
+
+
+class TestInterconnectionFlow:
+    """Tests for the InterconnectionFlow dataclass."""
+
+    def test_default_construction(self) -> None:
+        """InterconnectionFlow defaults to empty id and empty flow list."""
+        flow = InterconnectionFlow()
+        assert flow.interconnection_id == ""
+        assert flow.flow_mw == []
+
+    def test_construction_with_values(self) -> None:
+        """InterconnectionFlow stores provided values correctly."""
+        flow = InterconnectionFlow(
+            interconnection_id="ic_001",
+            flow_mw=[100.0, 200.0, -50.0],
+        )
+        assert flow.interconnection_id == "ic_001"
+        assert flow.flow_mw == [100.0, 200.0, -50.0]
+        assert len(flow.flow_mw) == 3
+
+
+# ======================================================================
+# TestInterconnectionLoader — YAML loading
+# ======================================================================
+
+
+class TestInterconnectionLoader:
+    """Tests for the InterconnectionLoader class."""
+
+    def test_load_all_9_interconnections(self, project_root: Path) -> None:
+        """Loader reads all 9 interconnection records from YAML."""
+        yaml_path = str(project_root / "data" / "reference" / "interconnections.yaml")
+        loader = InterconnectionLoader()
+        interconnections = loader.load(yaml_path)
+
+        assert len(interconnections) == 9
+
+    def test_loaded_records_are_interconnection_instances(
+        self, project_root: Path
+    ) -> None:
+        """All loaded records are Interconnection dataclass instances."""
+        yaml_path = str(project_root / "data" / "reference" / "interconnections.yaml")
+        loader = InterconnectionLoader()
+        interconnections = loader.load(yaml_path)
+
+        for ic in interconnections:
+            assert isinstance(ic, Interconnection)
+
+    def test_first_record_is_hokkaido_honshu_hvdc(
+        self, project_root: Path
+    ) -> None:
+        """First interconnection is the Hokkaido-Honshu HVDC link."""
+        yaml_path = str(project_root / "data" / "reference" / "interconnections.yaml")
+        loader = InterconnectionLoader()
+        interconnections = loader.load(yaml_path)
+
+        ic = interconnections[0]
+        assert ic.id == "ic_001"
+        assert ic.name_en == "Hokkaido-Honshu HVDC Link"
+        assert ic.from_region == "hokkaido"
+        assert ic.to_region == "tohoku"
+        assert ic.capacity_mw == 900.0
+        assert ic.type == "HVDC"
+
+    def test_tokyo_chubu_fc_interconnection(self, project_root: Path) -> None:
+        """Tokyo-Chubu FC interconnection has correct capacity and type."""
+        yaml_path = str(project_root / "data" / "reference" / "interconnections.yaml")
+        loader = InterconnectionLoader()
+        interconnections = loader.load(yaml_path)
+
+        # ic_003 is Tokyo-Chubu FC
+        ic_003 = [ic for ic in interconnections if ic.id == "ic_003"][0]
+        assert ic_003.from_region == "tokyo"
+        assert ic_003.to_region == "chubu"
+        assert ic_003.capacity_mw == 2100.0
+        assert ic_003.type == "FC"
+
+    def test_all_ids_unique(self, project_root: Path) -> None:
+        """All interconnection IDs are unique."""
+        yaml_path = str(project_root / "data" / "reference" / "interconnections.yaml")
+        loader = InterconnectionLoader()
+        interconnections = loader.load(yaml_path)
+
+        ids = [ic.id for ic in interconnections]
+        assert len(ids) == len(set(ids))
+
+    def test_all_capacities_positive(self, project_root: Path) -> None:
+        """All interconnection capacities are positive."""
+        yaml_path = str(project_root / "data" / "reference" / "interconnections.yaml")
+        loader = InterconnectionLoader()
+        interconnections = loader.load(yaml_path)
+
+        for ic in interconnections:
+            assert ic.capacity_mw > 0, f"{ic.id} has non-positive capacity"
+
+    def test_all_from_to_regions_differ(self, project_root: Path) -> None:
+        """No interconnection has the same from_region and to_region."""
+        yaml_path = str(project_root / "data" / "reference" / "interconnections.yaml")
+        loader = InterconnectionLoader()
+        interconnections = loader.load(yaml_path)
+
+        for ic in interconnections:
+            assert ic.from_region != ic.to_region, (
+                f"{ic.id} has same from/to region: {ic.from_region}"
+            )
+
+    def test_missing_file_raises_file_not_found_error(self) -> None:
+        """Loader raises FileNotFoundError for a non-existent YAML path."""
+        loader = InterconnectionLoader()
+        with pytest.raises(FileNotFoundError):
+            loader.load("/nonexistent/path/interconnections.yaml")
+
+
+# ======================================================================
+# TestPackageExports — public API
+# ======================================================================
+
+
+class TestPackageExports:
+    """Tests that Interconnection and InterconnectionFlow are exported from src.uc."""
+
+    def test_interconnection_importable_from_uc(self) -> None:
+        """Interconnection is importable from the src.uc package."""
+        from src.uc import Interconnection as IC
+
+        ic = IC(
+            id="test",
+            name_en="Test",
+            from_region="a",
+            to_region="b",
+            capacity_mw=100.0,
+        )
+        assert ic.id == "test"
+
+    def test_interconnection_flow_importable_from_uc(self) -> None:
+        """InterconnectionFlow is importable from the src.uc package."""
+        from src.uc import InterconnectionFlow as ICFlow
+
+        flow = ICFlow(interconnection_id="test", flow_mw=[1.0, 2.0])
+        assert flow.interconnection_id == "test"

--- a/tests/test_uc_interconnection.py
+++ b/tests/test_uc_interconnection.py
@@ -1,4 +1,4 @@
-"""Tests for interconnection data models and loader.
+"""Tests for interconnection data models, loader, and constraint builders.
 
 Tests cover:
 - Interconnection dataclass validation (empty id, negative capacity, same from/to region)
@@ -6,15 +6,25 @@ Tests cover:
 - InterconnectionLoader raises FileNotFoundError for missing file
 - InterconnectionFlow dataclass construction
 - Interconnection and InterconnectionFlow exports from src.uc
+- Transmission capacity constraint builder (flow bounded by capacity)
+- Nodal balance constraint builder (per-region generation + net flow >= demand)
+- Flow sign convention (positive = from_region -> to_region)
 """
 
 from pathlib import Path
+from typing import Dict, List, Tuple
 
+import pulp
 import pytest
 
+from src.model.generator import Generator
+from src.uc.constraints import (
+    add_nodal_balance_constraints,
+    add_transmission_capacity_constraints,
+)
 from src.uc.interconnection_loader import InterconnectionLoader
 from src.uc.models import Interconnection, InterconnectionFlow
-from tests.conftest import make_interconnection
+from tests.conftest import make_generator, make_interconnection
 
 
 # ======================================================================
@@ -192,6 +202,555 @@ class TestInterconnectionLoader:
         loader = InterconnectionLoader()
         with pytest.raises(FileNotFoundError):
             loader.load("/nonexistent/path/interconnections.yaml")
+
+
+# ======================================================================
+# TestTransmissionCapacityConstraints — constraint builder
+# ======================================================================
+
+
+class TestTransmissionCapacityConstraints:
+    """Tests for add_transmission_capacity_constraints() builder."""
+
+    def test_constraint_count_1ic_3timesteps(self) -> None:
+        """1 interconnection x 3 timesteps produces 6 constraints (2 per timestep)."""
+        model = pulp.LpProblem("test_tx_cap", pulp.LpMinimize)
+        ic = make_interconnection(id="ic_ab", capacity_mw=500.0)
+        timesteps = [0, 1, 2]
+
+        # Create flow variables (continuous, unbounded)
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for t in timesteps:
+            f[(ic.id, t)] = pulp.LpVariable(f"f_{ic.id}_{t}", cat="Continuous")
+
+        count = add_transmission_capacity_constraints(
+            model, f, [ic], timesteps
+        )
+
+        assert count == 6  # 1 IC x 3 timesteps x 2 (ub + lb)
+
+    def test_constraint_count_2ic_4timesteps(self) -> None:
+        """2 interconnections x 4 timesteps produces 16 constraints."""
+        model = pulp.LpProblem("test_tx_cap_2ic", pulp.LpMinimize)
+        ic1 = make_interconnection(id="ic_01", from_region="a", to_region="b", capacity_mw=300.0)
+        ic2 = make_interconnection(id="ic_02", from_region="b", to_region="c", capacity_mw=200.0)
+        timesteps = [0, 1, 2, 3]
+
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for ic in [ic1, ic2]:
+            for t in timesteps:
+                f[(ic.id, t)] = pulp.LpVariable(f"f_{ic.id}_{t}", cat="Continuous")
+
+        count = add_transmission_capacity_constraints(
+            model, f, [ic1, ic2], timesteps
+        )
+
+        assert count == 16  # 2 IC x 4 timesteps x 2
+
+    def test_constraint_names_follow_convention(self) -> None:
+        """Constraint names follow tx_cap_ub_{ic_id}_t{t} / tx_cap_lb_{ic_id}_t{t}."""
+        model = pulp.LpProblem("test_names", pulp.LpMinimize)
+        ic = make_interconnection(id="ic_test", capacity_mw=100.0)
+        timesteps = [0, 1]
+
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for t in timesteps:
+            f[(ic.id, t)] = pulp.LpVariable(f"f_{ic.id}_{t}", cat="Continuous")
+
+        add_transmission_capacity_constraints(model, f, [ic], timesteps)
+
+        constraint_names = set(model.constraints.keys())
+        assert "tx_cap_ub_ic_test_t0" in constraint_names
+        assert "tx_cap_lb_ic_test_t0" in constraint_names
+        assert "tx_cap_ub_ic_test_t1" in constraint_names
+        assert "tx_cap_lb_ic_test_t1" in constraint_names
+
+    def test_flow_within_upper_bound(self) -> None:
+        """Maximising flow is limited by capacity upper bound."""
+        model = pulp.LpProblem("test_ub", pulp.LpMaximize)
+        ic = make_interconnection(id="ic_ub", capacity_mw=500.0)
+        timesteps = [0]
+
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        f[(ic.id, 0)] = pulp.LpVariable("f_ic_ub_0", cat="Continuous")
+
+        # Maximise f => should hit upper bound at 500
+        model += f[(ic.id, 0)]
+        add_transmission_capacity_constraints(model, f, [ic], timesteps)
+
+        model.solve(pulp.PULP_CBC_CMD(msg=0))
+        assert pulp.LpStatus[model.status] == "Optimal"
+        assert abs(pulp.value(f[(ic.id, 0)]) - 500.0) < 1e-3
+
+    def test_flow_within_lower_bound(self) -> None:
+        """Minimising flow is limited by capacity lower bound (negative)."""
+        model = pulp.LpProblem("test_lb", pulp.LpMinimize)
+        ic = make_interconnection(id="ic_lb", capacity_mw=500.0)
+        timesteps = [0]
+
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        f[(ic.id, 0)] = pulp.LpVariable("f_ic_lb_0", cat="Continuous")
+
+        # Minimise f => should hit lower bound at -500
+        model += f[(ic.id, 0)]
+        add_transmission_capacity_constraints(model, f, [ic], timesteps)
+
+        model.solve(pulp.PULP_CBC_CMD(msg=0))
+        assert pulp.LpStatus[model.status] == "Optimal"
+        assert abs(pulp.value(f[(ic.id, 0)]) - (-500.0)) < 1e-3
+
+    def test_solve_multiple_timesteps_flow_bounded(self) -> None:
+        """Flow variables at all timesteps are bounded by capacity after solve."""
+        model = pulp.LpProblem("test_multi_t", pulp.LpMaximize)
+        ic = make_interconnection(id="ic_multi", capacity_mw=300.0)
+        timesteps = [0, 1, 2]
+
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for t in timesteps:
+            f[(ic.id, t)] = pulp.LpVariable(f"f_ic_multi_{t}", cat="Continuous")
+
+        # Maximise sum of flows
+        model += pulp.lpSum(f[(ic.id, t)] for t in timesteps)
+        add_transmission_capacity_constraints(model, f, [ic], timesteps)
+
+        model.solve(pulp.PULP_CBC_CMD(msg=0))
+        assert pulp.LpStatus[model.status] == "Optimal"
+
+        for t in timesteps:
+            flow_val = pulp.value(f[(ic.id, t)])
+            assert flow_val <= 300.0 + 1e-3, (
+                f"Flow at t={t} exceeds upper bound: {flow_val}"
+            )
+            assert flow_val >= -300.0 - 1e-3, (
+                f"Flow at t={t} below lower bound: {flow_val}"
+            )
+
+
+# ======================================================================
+# TestNodalBalanceConstraints — constraint builder
+# ======================================================================
+
+
+class TestNodalBalanceConstraints:
+    """Tests for add_nodal_balance_constraints() builder."""
+
+    def test_constraint_count_2regions_3timesteps(self) -> None:
+        """2 regions x 3 timesteps produces 6 nodal balance constraints."""
+        model = pulp.LpProblem("test_nodal", pulp.LpMinimize)
+
+        # 2 generators in different regions
+        g_a = make_generator(id="g_a", name="Gen A", region="region_a", capacity_mw=200.0)
+        g_b = make_generator(id="g_b", name="Gen B", region="region_b", capacity_mw=200.0)
+        generators = [g_a, g_b]
+
+        # 1 interconnection: region_a -> region_b
+        ic = make_interconnection(
+            id="ic_ab", from_region="region_a", to_region="region_b", capacity_mw=100.0,
+        )
+
+        timesteps = [0, 1, 2]
+
+        # Create power and flow variables
+        p: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for g in generators:
+            for t in timesteps:
+                p[(g.id, t)] = pulp.LpVariable(
+                    f"p_{g.id}_{t}", lowBound=0, upBound=g.capacity_mw,
+                )
+
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for t in timesteps:
+            f[(ic.id, t)] = pulp.LpVariable(f"f_{ic.id}_{t}", cat="Continuous")
+
+        regional_demand = {
+            "region_a": [100.0, 100.0, 100.0],
+            "region_b": [100.0, 100.0, 100.0],
+        }
+
+        count = add_nodal_balance_constraints(
+            model, p, f, generators, [ic], timesteps, regional_demand,
+        )
+
+        assert count == 6  # 2 regions x 3 timesteps
+
+    def test_constraint_names_follow_convention(self) -> None:
+        """Constraint names follow nodal_bal_{region}_t{t} convention."""
+        model = pulp.LpProblem("test_names", pulp.LpMinimize)
+
+        g_a = make_generator(id="g_a", name="Gen A", region="tokyo", capacity_mw=200.0)
+        g_b = make_generator(id="g_b", name="Gen B", region="chubu", capacity_mw=200.0)
+
+        ic = make_interconnection(
+            id="ic_tc", from_region="tokyo", to_region="chubu", capacity_mw=100.0,
+        )
+        timesteps = [0, 1]
+
+        p: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for g in [g_a, g_b]:
+            for t in timesteps:
+                p[(g.id, t)] = pulp.LpVariable(
+                    f"p_{g.id}_{t}", lowBound=0, upBound=g.capacity_mw,
+                )
+
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for t in timesteps:
+            f[(ic.id, t)] = pulp.LpVariable(f"f_{ic.id}_{t}", cat="Continuous")
+
+        regional_demand = {
+            "tokyo": [100.0, 100.0],
+            "chubu": [100.0, 100.0],
+        }
+
+        add_nodal_balance_constraints(
+            model, p, f, [g_a, g_b], [ic], timesteps, regional_demand,
+        )
+
+        constraint_names = set(model.constraints.keys())
+        assert "nodal_bal_tokyo_t0" in constraint_names
+        assert "nodal_bal_tokyo_t1" in constraint_names
+        assert "nodal_bal_chubu_t0" in constraint_names
+        assert "nodal_bal_chubu_t1" in constraint_names
+
+    def test_solve_regions_meet_demand(self) -> None:
+        """Both regions meet demand after solve with interconnection."""
+        model = pulp.LpProblem("test_demand_met", pulp.LpMinimize)
+
+        # Region A: 300 MW generator, demand 100 MW (surplus)
+        # Region B: 100 MW generator, demand 150 MW (deficit of 50 MW)
+        g_a = make_generator(
+            id="g_a", name="Gen A", region="region_a", capacity_mw=300.0,
+            fuel_cost_per_mwh=30.0,
+        )
+        g_b = make_generator(
+            id="g_b", name="Gen B", region="region_b", capacity_mw=100.0,
+            fuel_cost_per_mwh=50.0,
+        )
+        generators = [g_a, g_b]
+
+        # Interconnection allows 200 MW from A -> B
+        ic = make_interconnection(
+            id="ic_ab", from_region="region_a", to_region="region_b", capacity_mw=200.0,
+        )
+
+        timesteps = [0]
+
+        p: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for g in generators:
+            for t in timesteps:
+                p[(g.id, t)] = pulp.LpVariable(
+                    f"p_{g.id}_{t}", lowBound=0, upBound=g.capacity_mw,
+                )
+
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for t in timesteps:
+            f[(ic.id, t)] = pulp.LpVariable(f"f_{ic.id}_{t}", cat="Continuous")
+
+        regional_demand = {
+            "region_a": [100.0],
+            "region_b": [150.0],
+        }
+
+        # Objective: minimise generation cost
+        model += pulp.lpSum(
+            g.fuel_cost_per_mwh * p[(g.id, t)] for g in generators for t in timesteps
+        )
+
+        add_nodal_balance_constraints(
+            model, p, f, generators, [ic], timesteps, regional_demand,
+        )
+        add_transmission_capacity_constraints(model, f, [ic], timesteps)
+
+        model.solve(pulp.PULP_CBC_CMD(msg=0))
+        assert pulp.LpStatus[model.status] == "Optimal"
+
+        # Verify region A demand met: gen_a - export >= 100
+        gen_a_val = pulp.value(p[("g_a", 0)])
+        flow_val = pulp.value(f[("ic_ab", 0)])
+        assert gen_a_val - flow_val >= 100.0 - 1e-3, (
+            f"Region A balance violated: gen={gen_a_val}, flow_out={flow_val}"
+        )
+
+        # Verify region B demand met: gen_b + import >= 150
+        gen_b_val = pulp.value(p[("g_b", 0)])
+        assert gen_b_val + flow_val >= 150.0 - 1e-3, (
+            f"Region B balance violated: gen={gen_b_val}, flow_in={flow_val}"
+        )
+
+    def test_infeasible_when_capacity_insufficient(self) -> None:
+        """Model is infeasible when interconnection capacity is too small."""
+        model = pulp.LpProblem("test_infeasible", pulp.LpMinimize)
+
+        # Region A: 300 MW gen, demand 50 MW
+        # Region B: 50 MW gen, demand 200 MW (deficit 150 MW, IC cap only 100)
+        g_a = make_generator(
+            id="g_a", name="Gen A", region="region_a", capacity_mw=300.0,
+        )
+        g_b = make_generator(
+            id="g_b", name="Gen B", region="region_b", capacity_mw=50.0,
+        )
+        generators = [g_a, g_b]
+
+        ic = make_interconnection(
+            id="ic_ab", from_region="region_a", to_region="region_b", capacity_mw=100.0,
+        )
+
+        timesteps = [0]
+
+        p: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for g in generators:
+            for t in timesteps:
+                p[(g.id, t)] = pulp.LpVariable(
+                    f"p_{g.id}_{t}", lowBound=0, upBound=g.capacity_mw,
+                )
+
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for t in timesteps:
+            f[(ic.id, t)] = pulp.LpVariable(f"f_{ic.id}_{t}", cat="Continuous")
+
+        regional_demand = {
+            "region_a": [50.0],
+            "region_b": [200.0],  # needs 150 from IC but cap is 100
+        }
+
+        model += 0  # dummy objective
+        add_nodal_balance_constraints(
+            model, p, f, generators, [ic], timesteps, regional_demand,
+        )
+        add_transmission_capacity_constraints(model, f, [ic], timesteps)
+
+        model.solve(pulp.PULP_CBC_CMD(msg=0))
+        assert pulp.LpStatus[model.status] == "Infeasible"
+
+    def test_multiple_generators_per_region(self) -> None:
+        """Nodal balance correctly sums multiple generators in one region."""
+        model = pulp.LpProblem("test_multi_gen", pulp.LpMinimize)
+
+        # Region A: 2 generators (100 MW each), demand 180 MW
+        g_a1 = make_generator(id="g_a1", name="Gen A1", region="region_a", capacity_mw=100.0)
+        g_a2 = make_generator(id="g_a2", name="Gen A2", region="region_a", capacity_mw=100.0)
+        # Region B: 1 generator (200 MW), demand 50 MW
+        g_b = make_generator(id="g_b", name="Gen B", region="region_b", capacity_mw=200.0)
+        generators = [g_a1, g_a2, g_b]
+
+        ic = make_interconnection(
+            id="ic_ab", from_region="region_a", to_region="region_b", capacity_mw=50.0,
+        )
+
+        timesteps = [0]
+
+        p: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for g in generators:
+            for t in timesteps:
+                p[(g.id, t)] = pulp.LpVariable(
+                    f"p_{g.id}_{t}", lowBound=0, upBound=g.capacity_mw,
+                )
+
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for t in timesteps:
+            f[(ic.id, t)] = pulp.LpVariable(f"f_{ic.id}_{t}", cat="Continuous")
+
+        regional_demand = {
+            "region_a": [180.0],
+            "region_b": [50.0],
+        }
+
+        model += 0  # dummy objective
+        add_nodal_balance_constraints(
+            model, p, f, generators, [ic], timesteps, regional_demand,
+        )
+        add_transmission_capacity_constraints(model, f, [ic], timesteps)
+
+        model.solve(pulp.PULP_CBC_CMD(msg=0))
+        assert pulp.LpStatus[model.status] == "Optimal"
+
+        # Verify region A: g_a1 + g_a2 - export >= 180
+        gen_a_total = pulp.value(p[("g_a1", 0)]) + pulp.value(p[("g_a2", 0)])
+        flow_val = pulp.value(f[("ic_ab", 0)])
+        assert gen_a_total - flow_val >= 180.0 - 1e-3
+
+
+# ======================================================================
+# TestFlowSignConvention — positive = from_region -> to_region
+# ======================================================================
+
+
+class TestFlowSignConvention:
+    """Tests that positive flow represents power from from_region to to_region."""
+
+    def test_flow_sign_positive_from_surplus_to_deficit(self) -> None:
+        """Positive flow goes from from_region (surplus) to to_region (deficit)."""
+        model = pulp.LpProblem("test_sign", pulp.LpMinimize)
+
+        # Region A (from_region): 300 MW gen, demand 100 MW (surplus)
+        # Region B (to_region): 50 MW gen, demand 150 MW (deficit)
+        g_a = make_generator(
+            id="g_a", name="Gen A", region="region_a", capacity_mw=300.0,
+            fuel_cost_per_mwh=10.0,
+        )
+        g_b = make_generator(
+            id="g_b", name="Gen B", region="region_b", capacity_mw=50.0,
+            fuel_cost_per_mwh=10.0,
+        )
+        generators = [g_a, g_b]
+
+        # IC from region_a -> region_b
+        ic = make_interconnection(
+            id="ic_ab", from_region="region_a", to_region="region_b", capacity_mw=200.0,
+        )
+
+        timesteps = [0]
+
+        p: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for g in generators:
+            for t in timesteps:
+                p[(g.id, t)] = pulp.LpVariable(
+                    f"p_{g.id}_{t}", lowBound=0, upBound=g.capacity_mw,
+                )
+
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for t in timesteps:
+            f[(ic.id, t)] = pulp.LpVariable(f"f_{ic.id}_{t}", cat="Continuous")
+
+        regional_demand = {
+            "region_a": [100.0],
+            "region_b": [150.0],
+        }
+
+        # Minimise total generation cost
+        model += pulp.lpSum(
+            g.fuel_cost_per_mwh * p[(g.id, t)] for g in generators for t in timesteps
+        )
+
+        add_nodal_balance_constraints(
+            model, p, f, generators, [ic], timesteps, regional_demand,
+        )
+        add_transmission_capacity_constraints(model, f, [ic], timesteps)
+
+        model.solve(pulp.PULP_CBC_CMD(msg=0))
+        assert pulp.LpStatus[model.status] == "Optimal"
+
+        # Flow should be positive: power goes from region_a to region_b
+        flow_val = pulp.value(f[("ic_ab", 0)])
+        assert flow_val > 0, (
+            f"Expected positive flow from region_a to region_b, got {flow_val}"
+        )
+
+    def test_flow_sign_negative_when_reverse_direction(self) -> None:
+        """Negative flow means power goes from to_region to from_region (reverse)."""
+        model = pulp.LpProblem("test_neg_sign", pulp.LpMinimize)
+
+        # Region A (from_region): 50 MW gen, demand 150 MW (deficit)
+        # Region B (to_region): 300 MW gen, demand 100 MW (surplus)
+        g_a = make_generator(
+            id="g_a", name="Gen A", region="region_a", capacity_mw=50.0,
+            fuel_cost_per_mwh=10.0,
+        )
+        g_b = make_generator(
+            id="g_b", name="Gen B", region="region_b", capacity_mw=300.0,
+            fuel_cost_per_mwh=10.0,
+        )
+        generators = [g_a, g_b]
+
+        # IC still defined as from region_a -> region_b
+        ic = make_interconnection(
+            id="ic_ab", from_region="region_a", to_region="region_b", capacity_mw=200.0,
+        )
+
+        timesteps = [0]
+
+        p: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for g in generators:
+            for t in timesteps:
+                p[(g.id, t)] = pulp.LpVariable(
+                    f"p_{g.id}_{t}", lowBound=0, upBound=g.capacity_mw,
+                )
+
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for t in timesteps:
+            f[(ic.id, t)] = pulp.LpVariable(f"f_{ic.id}_{t}", cat="Continuous")
+
+        regional_demand = {
+            "region_a": [150.0],
+            "region_b": [100.0],
+        }
+
+        # Minimise total generation cost
+        model += pulp.lpSum(
+            g.fuel_cost_per_mwh * p[(g.id, t)] for g in generators for t in timesteps
+        )
+
+        add_nodal_balance_constraints(
+            model, p, f, generators, [ic], timesteps, regional_demand,
+        )
+        add_transmission_capacity_constraints(model, f, [ic], timesteps)
+
+        model.solve(pulp.PULP_CBC_CMD(msg=0))
+        assert pulp.LpStatus[model.status] == "Optimal"
+
+        # Flow should be negative: power goes from region_b to region_a (reverse)
+        flow_val = pulp.value(f[("ic_ab", 0)])
+        assert flow_val < 0, (
+            f"Expected negative flow (reverse direction), got {flow_val}"
+        )
+
+    def test_flow_sign_magnitude_matches_deficit(self) -> None:
+        """Flow magnitude matches the deficit that needs to be transferred."""
+        model = pulp.LpProblem("test_magnitude", pulp.LpMinimize)
+
+        # Region A: 300 MW gen, demand 100 MW
+        # Region B: 0 MW gen capacity (no gen), demand 80 MW
+        # Flow from A to B should be exactly 80 MW
+        g_a = make_generator(
+            id="g_a", name="Gen A", region="region_a", capacity_mw=300.0,
+            fuel_cost_per_mwh=10.0,
+        )
+        # Need a generator in region_b for the model (0 output possible)
+        g_b = make_generator(
+            id="g_b", name="Gen B", region="region_b", capacity_mw=0.0,
+            fuel_cost_per_mwh=100.0,
+        )
+        generators = [g_a, g_b]
+
+        ic = make_interconnection(
+            id="ic_ab", from_region="region_a", to_region="region_b", capacity_mw=200.0,
+        )
+
+        timesteps = [0]
+
+        p: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for g in generators:
+            for t in timesteps:
+                p[(g.id, t)] = pulp.LpVariable(
+                    f"p_{g.id}_{t}", lowBound=0, upBound=g.capacity_mw,
+                )
+
+        f: Dict[Tuple[str, int], pulp.LpVariable] = {}
+        for t in timesteps:
+            f[(ic.id, t)] = pulp.LpVariable(f"f_{ic.id}_{t}", cat="Continuous")
+
+        regional_demand = {
+            "region_a": [100.0],
+            "region_b": [80.0],
+        }
+
+        # Minimise total generation cost
+        model += pulp.lpSum(
+            g.fuel_cost_per_mwh * p[(g.id, t)] for g in generators for t in timesteps
+        )
+
+        add_nodal_balance_constraints(
+            model, p, f, generators, [ic], timesteps, regional_demand,
+        )
+        add_transmission_capacity_constraints(model, f, [ic], timesteps)
+
+        model.solve(pulp.PULP_CBC_CMD(msg=0))
+        assert pulp.LpStatus[model.status] == "Optimal"
+
+        flow_val = pulp.value(f[("ic_ab", 0)])
+        # Region B has no generation, so flow must equal region B demand
+        assert abs(flow_val - 80.0) < 1e-3, (
+            f"Expected flow of 80 MW to cover region_b deficit, got {flow_val}"
+        )
 
 
 # ======================================================================

--- a/tests/test_uc_interconnection.py
+++ b/tests/test_uc_interconnection.py
@@ -11,6 +11,10 @@ Tests cover:
 - Flow sign convention (positive = from_region -> to_region)
 - Two-region integration test via solve_uc with interconnection flow verification
 - Regression test: solve_uc without interconnections produces unchanged behavior
+- Decomposition fallback: RegionalDecomposer returns single partition with interconnections
+- Decomposition unchanged: RegionalDecomposer decomposes normally without interconnections
+- Config toggle: interconnection.enabled=false prevents loading/use
+- Decomposed solve with interconnections falls back to national MILP
 """
 
 from pathlib import Path
@@ -18,12 +22,14 @@ from typing import Dict, List, Tuple
 
 import pulp
 import pytest
+import yaml
 
 from src.model.generator import Generator
 from src.uc.constraints import (
     add_nodal_balance_constraints,
     add_transmission_capacity_constraints,
 )
+from src.uc.decomposition import RegionalDecomposer
 from src.uc.interconnection_loader import InterconnectionLoader
 from src.uc.models import (
     DemandProfile,
@@ -1001,3 +1007,419 @@ class TestSolveWithoutInterconnections:
         # Total cost equals sum of generator costs
         sum_gen_costs = sum(s.total_cost for s in result.schedules)
         assert abs(result.total_cost - sum_gen_costs) < 1.0
+
+
+# ======================================================================
+# Helpers — decomposition tests
+# ======================================================================
+
+
+def _make_two_region_generators() -> List[Generator]:
+    """Create generators across two regions for decomposition tests.
+
+    Returns 4 generators in 2 regions (total 500 MW):
+    - tokyo: g_tokyo_1 (200 MW coal), g_tokyo_2 (100 MW lng)
+    - chubu: g_chubu_1 (150 MW coal), g_chubu_2 (50 MW oil)
+    """
+    g1 = make_generator(
+        id="g_tokyo_1",
+        name="Tokyo Coal",
+        capacity_mw=200.0,
+        fuel_type="coal",
+        region="tokyo",
+        p_min_mw=50.0,
+        fuel_cost_per_mwh=30.0,
+        no_load_cost=100.0,
+        startup_cost=5000.0,
+    )
+    g2 = make_generator(
+        id="g_tokyo_2",
+        name="Tokyo LNG",
+        capacity_mw=100.0,
+        fuel_type="lng",
+        region="tokyo",
+        p_min_mw=20.0,
+        fuel_cost_per_mwh=50.0,
+        no_load_cost=50.0,
+        startup_cost=2000.0,
+    )
+    g3 = make_generator(
+        id="g_chubu_1",
+        name="Chubu Coal",
+        capacity_mw=150.0,
+        fuel_type="coal",
+        region="chubu",
+        p_min_mw=30.0,
+        fuel_cost_per_mwh=35.0,
+        no_load_cost=80.0,
+        startup_cost=4000.0,
+    )
+    g4 = make_generator(
+        id="g_chubu_2",
+        name="Chubu Oil",
+        capacity_mw=50.0,
+        fuel_type="oil",
+        region="chubu",
+        p_min_mw=10.0,
+        fuel_cost_per_mwh=80.0,
+        no_load_cost=20.0,
+        startup_cost=1000.0,
+    )
+    return [g1, g2, g3, g4]
+
+
+# ======================================================================
+# TestDecompositionFallback — RegionalDecomposer with interconnections
+# ======================================================================
+
+
+class TestDecompositionFallback:
+    """Tests that RegionalDecomposer falls back to national MILP with interconnections."""
+
+    def test_decomposition_fallback_with_interconnections(self) -> None:
+        """RegionalDecomposer returns [params] when interconnections are present."""
+        gens = _make_two_region_generators()
+        th = TimeHorizon(num_periods=6, period_duration_h=1.0)
+        dp = _flat_demand(200.0, 6)
+
+        ic = make_interconnection(
+            id="ic_tc",
+            from_region="tokyo",
+            to_region="chubu",
+            capacity_mw=100.0,
+        )
+
+        params = UCParameters(
+            generators=gens,
+            demand=dp,
+            time_horizon=th,
+            interconnections=[ic],
+        )
+
+        decomposer = RegionalDecomposer()
+        partitions = decomposer.partition(params)
+
+        # Should return single partition (no decomposition)
+        assert len(partitions) == 1
+        assert partitions[0] is params
+
+    def test_decomposition_fallback_preserves_all_generators(self) -> None:
+        """Fallback partition contains all original generators."""
+        gens = _make_two_region_generators()
+        th = TimeHorizon(num_periods=6, period_duration_h=1.0)
+        dp = _flat_demand(200.0, 6)
+
+        ic = make_interconnection(
+            id="ic_tc",
+            from_region="tokyo",
+            to_region="chubu",
+            capacity_mw=100.0,
+        )
+
+        params = UCParameters(
+            generators=gens,
+            demand=dp,
+            time_horizon=th,
+            interconnections=[ic],
+        )
+
+        decomposer = RegionalDecomposer()
+        partitions = decomposer.partition(params)
+
+        gen_ids = {g.id for g in partitions[0].generators}
+        expected_ids = {g.id for g in gens}
+        assert gen_ids == expected_ids
+
+    def test_decomposition_fallback_preserves_interconnections(self) -> None:
+        """Fallback partition preserves the interconnections list."""
+        gens = _make_two_region_generators()
+        th = TimeHorizon(num_periods=6, period_duration_h=1.0)
+        dp = _flat_demand(200.0, 6)
+
+        ic1 = make_interconnection(
+            id="ic_01", from_region="tokyo", to_region="chubu", capacity_mw=100.0,
+        )
+        ic2 = make_interconnection(
+            id="ic_02", from_region="chubu", to_region="tokyo", capacity_mw=200.0,
+        )
+
+        params = UCParameters(
+            generators=gens,
+            demand=dp,
+            time_horizon=th,
+            interconnections=[ic1, ic2],
+        )
+
+        decomposer = RegionalDecomposer()
+        partitions = decomposer.partition(params)
+
+        assert len(partitions[0].interconnections) == 2
+        ic_ids = {ic.id for ic in partitions[0].interconnections}
+        assert ic_ids == {"ic_01", "ic_02"}
+
+    def test_decomposition_without_interconnections_unchanged(self) -> None:
+        """RegionalDecomposer decomposes normally when interconnections list is empty."""
+        gens = _make_two_region_generators()
+        th = TimeHorizon(num_periods=6, period_duration_h=1.0)
+        dp = _flat_demand(200.0, 6)
+
+        params = UCParameters(
+            generators=gens,
+            demand=dp,
+            time_horizon=th,
+            interconnections=[],  # No interconnections
+        )
+
+        decomposer = RegionalDecomposer()
+        partitions = decomposer.partition(params)
+
+        # Should decompose into 2 regions (tokyo + chubu)
+        assert len(partitions) == 2
+
+        # Verify each partition has generators from only one region
+        for p in partitions:
+            regions = {g.region for g in p.generators}
+            assert len(regions) == 1, (
+                f"Partition has generators from multiple regions: {regions}"
+            )
+
+    def test_decomposition_without_interconnections_field_decomposes(self) -> None:
+        """RegionalDecomposer decomposes when interconnections defaults (empty)."""
+        gens = _make_two_region_generators()
+        th = TimeHorizon(num_periods=6, period_duration_h=1.0)
+        dp = _flat_demand(200.0, 6)
+
+        # Don't pass interconnections — uses default empty list
+        params = UCParameters(
+            generators=gens,
+            demand=dp,
+            time_horizon=th,
+        )
+
+        decomposer = RegionalDecomposer()
+        partitions = decomposer.partition(params)
+
+        # Should decompose into 2 regions
+        assert len(partitions) == 2
+
+
+# ======================================================================
+# TestConfigToggle — interconnection.enabled config flag
+# ======================================================================
+
+
+class TestConfigToggle:
+    """Tests for the interconnection.enabled configuration toggle."""
+
+    def test_config_toggle_disabled(self, project_root: Path) -> None:
+        """With interconnection.enabled=false, interconnections are not loaded/used."""
+        config_path = project_root / "config" / "uc_config.yaml"
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+
+        ic_config = config.get("interconnection", {})
+
+        # Default config has enabled=false
+        assert ic_config.get("enabled") is False, (
+            "Default config should have interconnection.enabled=false"
+        )
+
+        # When disabled, a solve should NOT use interconnections
+        # Create a simple 2-region problem
+        gens = _make_two_region_generators()
+        th = TimeHorizon(num_periods=6, period_duration_h=1.0)
+        dp = _flat_demand(200.0, 6)
+
+        # Simulate config-driven behavior: if not enabled, don't add interconnections
+        if not ic_config.get("enabled", False):
+            params = UCParameters(
+                generators=gens,
+                demand=dp,
+                time_horizon=th,
+                interconnections=[],  # Disabled → no interconnections
+            )
+        else:
+            # This branch would load from data_path
+            loader = InterconnectionLoader()
+            ics = loader.load(str(project_root / ic_config["data_path"]))
+            params = UCParameters(
+                generators=gens,
+                demand=dp,
+                time_horizon=th,
+                interconnections=ics,
+            )
+
+        result = solve_uc(params)
+
+        assert result.status == "Optimal"
+        # With disabled config, no interconnection flows should be present
+        assert len(result.interconnection_flows) == 0
+
+    def test_config_has_data_path(self, project_root: Path) -> None:
+        """Config specifies a valid data_path for interconnections YAML."""
+        config_path = project_root / "config" / "uc_config.yaml"
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+
+        ic_config = config.get("interconnection", {})
+        data_path = ic_config.get("data_path")
+        assert data_path is not None, "interconnection.data_path should be set"
+        assert data_path == "data/reference/interconnections.yaml"
+
+        # Verify the file actually exists
+        full_path = project_root / data_path
+        assert full_path.exists(), f"Interconnection data file not found: {full_path}"
+
+    def test_config_toggle_enabled_loads_interconnections(
+        self, project_root: Path
+    ) -> None:
+        """When enabled=true would be set, interconnections can be loaded from data_path."""
+        config_path = project_root / "config" / "uc_config.yaml"
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+
+        ic_config = config.get("interconnection", {})
+        data_path = ic_config.get("data_path")
+
+        # Simulate enabled=true: load interconnections from data_path
+        loader = InterconnectionLoader()
+        ics = loader.load(str(project_root / data_path))
+
+        assert len(ics) == 9
+        assert all(isinstance(ic, Interconnection) for ic in ics)
+
+
+# ======================================================================
+# TestRegionalDecomposerSolveWithInterconnections — solve_decomposed
+# ======================================================================
+
+
+class TestRegionalDecomposerSolveWithInterconnections:
+    """Tests that solve_decomposed() falls back to national MILP with interconnections."""
+
+    def test_regional_decomposer_solve_with_interconnections(self) -> None:
+        """solve_decomposed() falls back to national MILP and produces Optimal result."""
+        gens = _make_two_region_generators()
+        th = TimeHorizon(num_periods=6, period_duration_h=1.0)
+        # Low demand so the problem is easily feasible
+        dp = _flat_demand(200.0, 6)
+
+        ic = make_interconnection(
+            id="ic_tc",
+            from_region="tokyo",
+            to_region="chubu",
+            capacity_mw=100.0,
+        )
+
+        params = UCParameters(
+            generators=gens,
+            demand=dp,
+            time_horizon=th,
+            interconnections=[ic],
+        )
+
+        decomposer = RegionalDecomposer()
+        result = decomposer.solve_decomposed(params)
+
+        assert result.status == "Optimal"
+        assert result.total_cost > 0
+        assert result.solve_time_s >= 0
+
+    def test_solve_decomposed_has_all_generators(self) -> None:
+        """Merged result from solve_decomposed contains all generators."""
+        gens = _make_two_region_generators()
+        th = TimeHorizon(num_periods=6, period_duration_h=1.0)
+        dp = _flat_demand(200.0, 6)
+
+        ic = make_interconnection(
+            id="ic_tc",
+            from_region="tokyo",
+            to_region="chubu",
+            capacity_mw=100.0,
+        )
+
+        params = UCParameters(
+            generators=gens,
+            demand=dp,
+            time_horizon=th,
+            interconnections=[ic],
+        )
+
+        decomposer = RegionalDecomposer()
+        result = decomposer.solve_decomposed(params)
+
+        gen_ids_in_result = {s.generator_id for s in result.schedules}
+        expected_ids = {g.id for g in gens}
+        assert gen_ids_in_result == expected_ids, (
+            f"Missing: {expected_ids - gen_ids_in_result}, "
+            f"Extra: {gen_ids_in_result - expected_ids}"
+        )
+
+    def test_solve_decomposed_single_partition_solves_with_interconnections(
+        self,
+    ) -> None:
+        """Single partition from fallback produces correct solve_uc result with flows."""
+        gens = _make_two_region_generators()
+        th = TimeHorizon(num_periods=6, period_duration_h=1.0)
+        dp = _flat_demand(200.0, 6)
+
+        ic = make_interconnection(
+            id="ic_tc",
+            from_region="tokyo",
+            to_region="chubu",
+            capacity_mw=100.0,
+        )
+
+        params = UCParameters(
+            generators=gens,
+            demand=dp,
+            time_horizon=th,
+            interconnections=[ic],
+        )
+
+        # Verify the partition returns [params] and solve_uc on that
+        # partition produces interconnection flows correctly.
+        decomposer = RegionalDecomposer()
+        partitions = decomposer.partition(params)
+        assert len(partitions) == 1
+
+        # Solve the single partition directly (as solve_decomposed does)
+        direct_result = solve_uc(partitions[0])
+        assert direct_result.status == "Optimal"
+        assert len(direct_result.interconnection_flows) == 1
+        assert direct_result.interconnection_flows[0].interconnection_id == "ic_tc"
+        assert len(direct_result.interconnection_flows[0].flow_mw) == 6
+
+    def test_solve_decomposed_schedule_lengths(self) -> None:
+        """All schedules from solve_decomposed have correct length."""
+        gens = _make_two_region_generators()
+        num_periods = 6
+        th = TimeHorizon(num_periods=num_periods, period_duration_h=1.0)
+        dp = _flat_demand(200.0, num_periods)
+
+        ic = make_interconnection(
+            id="ic_tc",
+            from_region="tokyo",
+            to_region="chubu",
+            capacity_mw=100.0,
+        )
+
+        params = UCParameters(
+            generators=gens,
+            demand=dp,
+            time_horizon=th,
+            interconnections=[ic],
+        )
+
+        decomposer = RegionalDecomposer()
+        result = decomposer.solve_decomposed(params)
+
+        for sched in result.schedules:
+            assert len(sched.commitment) == num_periods, (
+                f"Generator {sched.generator_id}: commitment length "
+                f"{len(sched.commitment)} != {num_periods}"
+            )
+            assert len(sched.power_output_mw) == num_periods, (
+                f"Generator {sched.generator_id}: power_output length "
+                f"{len(sched.power_output_mw)} != {num_periods}"
+            )


### PR DESCRIPTION
Add inter-regional interconnection capacity constraints to the Unit Commitment (UC) solver for Japan's national power grid. Currently, the regional decomposition strategy (`RegionalDecomposer`) solves each of Japan's 10 power grid regions as independent MILPs with no coupling, implicitly assuming unlimited power transfer between regions. This task introduces continuous flow variables `f[ic,t]` for each of the 9 OCCTO interconnections, nodal (per-region) power balance constraints, and transmission capacity bounds. Because interconnection constraints couple regions, the solver must automatically fall back from regional decomposition to a single national MILP (657 generators x 24 hours) when interconnections are enabled. The existing `data/reference/interconnections.yaml` already contains all 9 interconnection records with OCCTO-sourced capacity data; no new data sourcing is needed. The existing 9-constraint UC formulation (demand balance, capacity bounds, startup/shutdown logic, min-uptime, min-downtime, ramp rates, maintenance, reserve margin, storage SOC) must remain unmodified for non-storage, non-interconnection generators.