### PR TITLE
UC 17: validation loop live — UC vs per-fuel measured actuals (5 regions)

### DIFF
--- a/config/dataspace.yaml
+++ b/config/dataspace.yaml
@@ -60,7 +60,7 @@ providers:
     license: 元データの各電力会社公表条件に従う（生データ再配布不可）
     redistribute_raw: false
     redistribute_derived: true
-    connector: null            # Phase A実装予定（docs/UC_VALIDATION_PLAN.md）
+    connector: nas03           # Phase A-1実装済み（新形式=2024-04以降の月次）
     variables:
       - {name: area_generation_actual,
          desc: "demand_raw/{company}/ 10社・30分値・電源種別 (原子力/LNG/石炭/石油/水力/地熱/バイオ/太陽光+制御/風力+制御/揚水/蓄電池/連系線)"}

--- a/docs/reports/IMPROVEMENT_LOG.md
+++ b/docs/reports/IMPROVEMENT_LOG.md
@@ -37,6 +37,32 @@ KPIは `ajgrid validate --topology --all --solve` の計測値
 <!-- ── UC改善シリーズ（worktree uc-improvements） ── -->
 
 
+## 2026-06-12 — **Fable 5** — UC改善⑰: 検証ループ稼働（Phase A-1）— UC vs 発電実績の地域×燃料突合
+
+- **nas03/PWS_DBコネクタ**(`e06d448`): エリア需給実績（10社・30分値・電源種別）を
+  ssh zero-copyで月単位取得。列名マップでhokkaido変種（制御量+2列）を吸収、
+  制御量列の本体上書きバグ修正、**tepcoのUTF-8-SIG**対応（CP932固定だと
+  列名が化けdemand列消失→全行棄却=tokyoが空に見えた。多段デコードで解決）
+- **uc_validate.py**: 代表日2025-08-06のfy2025r1 UC解 vs 5社実績
+  （hokkaido/tohoku/tepco/hokuriku/shikoku — 202508新形式在庫のある社）。
+  地域×燃料の日エネルギー・シェアL1・時間形状相関・抑制量を出力、
+  uc_runs(kind=validation)記録
+- **ベースラインL1**: tokyo **12.7pp**（最良）/ hokuriku 33.1 / shikoku 41.3 /
+  hokkaido 44.0 / tohoku 69.7（平均40.2pp）
+- **実測で立証されたこと**: ①hokuriku coal **61.2 vs 62.0 GWh/日でほぼ一致** —
+  七尾大田・敦賀の容量パッチが実績と整合（⑮の検証）②solar形状相関0.89-0.96 —
+  実測needs+参照CFの時間形状は正確、バイアスは量側
+- **自己改善1巡目**: 24h断面にRE/RoRの**月係数が未適用**だった（年平均CFのまま
+  → 8月弱風期にtohoku windが実績の3倍）→ 代表日の月で季節係数を適用
+  （年間経路と整合化）。ただし**平均L1は40.2→40.8ppとほぼ不変** — windを
+  正すと浮いた分をcoalが受けて相殺。**L1残差の支配項はcoal/lngスワップ
+  （tohoku +85/-105 GWh/日 = 経済停止の構造、タスク#12）に集約**と確定
+- 残課題の地域分解: tohoku geothermal 6.5倍過大（UC 729MW vs 実績132MW、
+  個別機調査=Phase A-2）/ tepco実績は全日あり（欠測ではなかった）/
+  kansai・chugoku・kyushuは202508在庫なし（Phase Bで旧形式対応）
+- 再現: `AJGRID_NAS03_ROOT=ssh://… python3 scripts/uc_validate.py
+  --scenario fy2025r1 --date 2025-08-06`（コネクタテスト6+15 passed）
+
 ## 2026-06-12 — **Fable 5** — UC改善⑯: west島UC断面の初AC収束 + before/afterマップ（merit-order vs UCコミットメント）
 
 - **west島がUC注入断面でAC収束（本プロジェクト初）**: mainのmulti-voltage builder

--- a/docs/reports/uc_validation_fy2025r1_2025-08-06.json
+++ b/docs/reports/uc_validation_fy2025r1_2025-08-06.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "date": "2026-06-12",
-    "git_head": "2cc433c",
+    "git_head": "e06d448",
     "scenario": "fy2025r1",
     "validation_date": "2025-08-06",
     "companies": [
@@ -29,10 +29,10 @@
           "shape_corr": null
         },
         "coal": {
-          "uc_mwh": 54630.4,
+          "uc_mwh": 56785.5,
           "measured_mwh": 31150.5,
-          "diff_mwh": 23479.9,
-          "shape_corr": 0.405
+          "diff_mwh": 25635.0,
+          "shape_corr": 0.666
         },
         "oil": {
           "uc_mwh": 0.0,
@@ -65,25 +65,25 @@
           "shape_corr": 0.85
         },
         "wind": {
-          "uc_mwh": 6776.2,
+          "uc_mwh": 4743.4,
           "measured_mwh": 7162.5,
-          "diff_mwh": -386.2,
+          "diff_mwh": -2419.1,
           "shape_corr": -0.561
         },
         "pumped_hydro": {
-          "uc_mwh": 705.6,
+          "uc_mwh": 1642.3,
           "measured_mwh": 512.5,
-          "diff_mwh": 193.1,
-          "shape_corr": 0.365
+          "diff_mwh": 1129.8,
+          "shape_corr": 0.393
         },
         "battery": {
-          "uc_mwh": 847.4,
+          "uc_mwh": 769.3,
           "measured_mwh": -50.0,
-          "diff_mwh": 897.4,
-          "shape_corr": 0.242
+          "diff_mwh": 819.3,
+          "shape_corr": 0.269
         }
       },
-      "share_l1_pp": 43.98,
+      "share_l1_pp": 47.81,
       "curtailment_mwh": {
         "solar": 0.0,
         "wind": 0.0
@@ -100,16 +100,16 @@
           "shape_corr": null
         },
         "lng": {
-          "uc_mwh": 6914.8,
+          "uc_mwh": 8082.9,
           "measured_mwh": 111424.0,
-          "diff_mwh": -104509.2,
-          "shape_corr": 0.481
+          "diff_mwh": -103341.1,
+          "shape_corr": 0.462
         },
         "coal": {
-          "uc_mwh": 233645.8,
+          "uc_mwh": 236404.2,
           "measured_mwh": 148589.5,
-          "diff_mwh": 85056.3,
-          "shape_corr": 0.466
+          "diff_mwh": 87814.7,
+          "shape_corr": 0.284
         },
         "oil": {
           "uc_mwh": 0.0,
@@ -142,25 +142,25 @@
           "shape_corr": 0.959
         },
         "wind": {
-          "uc_mwh": 15612.5,
+          "uc_mwh": 10928.7,
           "measured_mwh": 5111.0,
-          "diff_mwh": 10501.5,
+          "diff_mwh": 5817.7,
           "shape_corr": 0.735
         },
         "pumped_hydro": {
-          "uc_mwh": 1212.1,
+          "uc_mwh": 1234.9,
           "measured_mwh": -491.0,
-          "diff_mwh": 1703.1,
-          "shape_corr": 0.545
+          "diff_mwh": 1725.9,
+          "shape_corr": 0.467
         },
         "battery": {
-          "uc_mwh": 1584.5,
+          "uc_mwh": 1186.7,
           "measured_mwh": -53.0,
-          "diff_mwh": 1637.5,
-          "shape_corr": 0.305
+          "diff_mwh": 1239.7,
+          "shape_corr": 0.289
         }
       },
-      "share_l1_pp": 69.71,
+      "share_l1_pp": 69.04,
       "curtailment_mwh": {
         "solar": 0.0,
         "wind": 0.0
@@ -171,10 +171,10 @@
       "demand_measured_mwh": 1076789.0,
       "per_fuel": {
         "lng": {
-          "uc_mwh": 562830.3,
+          "uc_mwh": 573209.4,
           "measured_mwh": 574299.5,
-          "diff_mwh": -11469.2,
-          "shape_corr": 0.967
+          "diff_mwh": -1090.1,
+          "shape_corr": 0.945
         },
         "coal": {
           "uc_mwh": 212496.0,
@@ -183,10 +183,10 @@
           "shape_corr": null
         },
         "oil": {
-          "uc_mwh": 245.3,
+          "uc_mwh": 334.6,
           "measured_mwh": 52562.0,
-          "diff_mwh": -52316.7,
-          "shape_corr": 0.237
+          "diff_mwh": -52227.4,
+          "shape_corr": 0.319
         },
         "hydro": {
           "uc_mwh": 36331.2,
@@ -207,19 +207,19 @@
           "shape_corr": 0.968
         },
         "wind": {
-          "uc_mwh": 379.5,
+          "uc_mwh": 265.6,
           "measured_mwh": 2380.5,
-          "diff_mwh": -2001.0,
+          "diff_mwh": -2114.9,
           "shape_corr": 0.717
         },
         "battery": {
           "uc_mwh": 186.0,
           "measured_mwh": 105.0,
           "diff_mwh": 81.0,
-          "shape_corr": 0.01
+          "shape_corr": -0.1
         }
       },
-      "share_l1_pp": 12.66,
+      "share_l1_pp": 12.86,
       "curtailment_mwh": {
         "solar": 0.0,
         "wind": 0.0
@@ -266,9 +266,9 @@
           "shape_corr": 0.886
         },
         "wind": {
-          "uc_mwh": 1030.0,
+          "uc_mwh": 721.0,
           "measured_mwh": 918.0,
-          "diff_mwh": 112.0,
+          "diff_mwh": -197.0,
           "shape_corr": 0.315
         },
         "pumped_hydro": {
@@ -284,7 +284,7 @@
           "shape_corr": null
         }
       },
-      "share_l1_pp": 33.06,
+      "share_l1_pp": 33.27,
       "curtailment_mwh": {
         "solar": 0.0,
         "wind": 0.0
@@ -337,19 +337,19 @@
           "shape_corr": 0.988
         },
         "wind": {
-          "uc_mwh": 1707.6,
+          "uc_mwh": 1195.3,
           "measured_mwh": 228.0,
-          "diff_mwh": 1479.6,
+          "diff_mwh": 967.3,
           "shape_corr": 0.462
         },
         "battery": {
-          "uc_mwh": 315.3,
+          "uc_mwh": 185.5,
           "measured_mwh": -18.0,
-          "diff_mwh": 333.3,
-          "shape_corr": 0.159
+          "diff_mwh": 203.5,
+          "shape_corr": 0.113
         }
       },
-      "share_l1_pp": 41.33,
+      "share_l1_pp": 41.07,
       "curtailment_mwh": {
         "solar": 0.0,
         "wind": 0.0
@@ -358,12 +358,12 @@
   },
   "summary": {
     "l1_pp_by_region": {
-      "hokkaido": 43.98,
-      "tohoku": 69.71,
-      "tokyo": 12.66,
-      "hokuriku": 33.06,
-      "shikoku": 41.33
+      "hokkaido": 47.81,
+      "tohoku": 69.04,
+      "tokyo": 12.86,
+      "hokuriku": 33.27,
+      "shikoku": 41.07
     },
-    "l1_pp_mean": 40.15
+    "l1_pp_mean": 40.81
   }
 }

--- a/docs/reports/uc_validation_fy2025r1_2025-08-06.json
+++ b/docs/reports/uc_validation_fy2025r1_2025-08-06.json
@@ -1,0 +1,369 @@
+{
+  "meta": {
+    "date": "2026-06-12",
+    "git_head": "2cc433c",
+    "scenario": "fy2025r1",
+    "validation_date": "2025-08-06",
+    "companies": [
+      "hokkaido",
+      "tohoku",
+      "tepco",
+      "hokuriku",
+      "shikoku"
+    ],
+    "vocabulary_notes": [
+      "UC oil = 実績 火力(石油)+火力(その他)（区分差の開示）",
+      "UC solar/wind はシナリオ参照値（fy2025r1はFY2023容量踏襲=FY2025導入増未較正のバイアスをここで実測する）",
+      "実績は30分MW平均→1h平均、UCは1h値"
+    ]
+  },
+  "regions": {
+    "hokkaido": {
+      "company": "hokkaido",
+      "demand_measured_mwh": 85998.0,
+      "per_fuel": {
+        "lng": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 1977.5,
+          "diff_mwh": -1977.5,
+          "shape_corr": null
+        },
+        "coal": {
+          "uc_mwh": 54630.4,
+          "measured_mwh": 31150.5,
+          "diff_mwh": 23479.9,
+          "shape_corr": 0.405
+        },
+        "oil": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 14470.5,
+          "diff_mwh": -14470.5,
+          "shape_corr": null
+        },
+        "hydro": {
+          "uc_mwh": 20040.0,
+          "measured_mwh": 13537.5,
+          "diff_mwh": 6502.5,
+          "shape_corr": null
+        },
+        "geothermal": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 24.0,
+          "diff_mwh": -24.0,
+          "shape_corr": null
+        },
+        "biomass": {
+          "uc_mwh": 11400.0,
+          "measured_mwh": 6481.5,
+          "diff_mwh": 4918.5,
+          "shape_corr": null
+        },
+        "solar": {
+          "uc_mwh": 14068.3,
+          "measured_mwh": 8432.0,
+          "diff_mwh": 5636.3,
+          "shape_corr": 0.85
+        },
+        "wind": {
+          "uc_mwh": 6776.2,
+          "measured_mwh": 7162.5,
+          "diff_mwh": -386.2,
+          "shape_corr": -0.561
+        },
+        "pumped_hydro": {
+          "uc_mwh": 705.6,
+          "measured_mwh": 512.5,
+          "diff_mwh": 193.1,
+          "shape_corr": 0.365
+        },
+        "battery": {
+          "uc_mwh": 847.4,
+          "measured_mwh": -50.0,
+          "diff_mwh": 897.4,
+          "shape_corr": 0.242
+        }
+      },
+      "share_l1_pp": 43.98,
+      "curtailment_mwh": {
+        "solar": 0.0,
+        "wind": 0.0
+      }
+    },
+    "tohoku": {
+      "company": "tohoku",
+      "demand_measured_mwh": 240802.5,
+      "per_fuel": {
+        "nuclear": {
+          "uc_mwh": 19800.0,
+          "measured_mwh": 18841.0,
+          "diff_mwh": 959.0,
+          "shape_corr": null
+        },
+        "lng": {
+          "uc_mwh": 6914.8,
+          "measured_mwh": 111424.0,
+          "diff_mwh": -104509.2,
+          "shape_corr": 0.481
+        },
+        "coal": {
+          "uc_mwh": 233645.8,
+          "measured_mwh": 148589.5,
+          "diff_mwh": 85056.3,
+          "shape_corr": 0.466
+        },
+        "oil": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 9975.5,
+          "diff_mwh": -9975.5,
+          "shape_corr": null
+        },
+        "hydro": {
+          "uc_mwh": 27710.4,
+          "measured_mwh": 26129.0,
+          "diff_mwh": 1581.4,
+          "shape_corr": null
+        },
+        "geothermal": {
+          "uc_mwh": 17503.2,
+          "measured_mwh": 2688.0,
+          "diff_mwh": 14815.2,
+          "shape_corr": null
+        },
+        "biomass": {
+          "uc_mwh": 5337.6,
+          "measured_mwh": 16740.5,
+          "diff_mwh": -11402.9,
+          "shape_corr": null
+        },
+        "solar": {
+          "uc_mwh": 32298.9,
+          "measured_mwh": 22245.5,
+          "diff_mwh": 10053.4,
+          "shape_corr": 0.959
+        },
+        "wind": {
+          "uc_mwh": 15612.5,
+          "measured_mwh": 5111.0,
+          "diff_mwh": 10501.5,
+          "shape_corr": 0.735
+        },
+        "pumped_hydro": {
+          "uc_mwh": 1212.1,
+          "measured_mwh": -491.0,
+          "diff_mwh": 1703.1,
+          "shape_corr": 0.545
+        },
+        "battery": {
+          "uc_mwh": 1584.5,
+          "measured_mwh": -53.0,
+          "diff_mwh": 1637.5,
+          "shape_corr": 0.305
+        }
+      },
+      "share_l1_pp": 69.71,
+      "curtailment_mwh": {
+        "solar": 0.0,
+        "wind": 0.0
+      }
+    },
+    "tokyo": {
+      "company": "tepco",
+      "demand_measured_mwh": 1076789.0,
+      "per_fuel": {
+        "lng": {
+          "uc_mwh": 562830.3,
+          "measured_mwh": 574299.5,
+          "diff_mwh": -11469.2,
+          "shape_corr": 0.967
+        },
+        "coal": {
+          "uc_mwh": 212496.0,
+          "measured_mwh": 189534.5,
+          "diff_mwh": 22961.5,
+          "shape_corr": null
+        },
+        "oil": {
+          "uc_mwh": 245.3,
+          "measured_mwh": 52562.0,
+          "diff_mwh": -52316.7,
+          "shape_corr": 0.237
+        },
+        "hydro": {
+          "uc_mwh": 36331.2,
+          "measured_mwh": 34242.5,
+          "diff_mwh": 2088.7,
+          "shape_corr": null
+        },
+        "biomass": {
+          "uc_mwh": 12763.2,
+          "measured_mwh": 10388.5,
+          "diff_mwh": 2374.7,
+          "shape_corr": null
+        },
+        "solar": {
+          "uc_mwh": 78142.5,
+          "measured_mwh": 88300.0,
+          "diff_mwh": -10157.5,
+          "shape_corr": 0.968
+        },
+        "wind": {
+          "uc_mwh": 379.5,
+          "measured_mwh": 2380.5,
+          "diff_mwh": -2001.0,
+          "shape_corr": 0.717
+        },
+        "battery": {
+          "uc_mwh": 186.0,
+          "measured_mwh": 105.0,
+          "diff_mwh": 81.0,
+          "shape_corr": 0.01
+        }
+      },
+      "share_l1_pp": 12.66,
+      "curtailment_mwh": {
+        "solar": 0.0,
+        "wind": 0.0
+      }
+    },
+    "hokuriku": {
+      "company": "hokuriku",
+      "demand_measured_mwh": 89050.5,
+      "per_fuel": {
+        "lng": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 6490.5,
+          "diff_mwh": -6490.5,
+          "shape_corr": null
+        },
+        "coal": {
+          "uc_mwh": 61176.0,
+          "measured_mwh": 62039.5,
+          "diff_mwh": -863.5,
+          "shape_corr": null
+        },
+        "oil": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 8995.5,
+          "diff_mwh": -8995.5,
+          "shape_corr": null
+        },
+        "hydro": {
+          "uc_mwh": 24765.6,
+          "measured_mwh": 20431.0,
+          "diff_mwh": 4334.6,
+          "shape_corr": null
+        },
+        "biomass": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 1491.5,
+          "diff_mwh": -1491.5,
+          "shape_corr": null
+        },
+        "solar": {
+          "uc_mwh": 6863.0,
+          "measured_mwh": 4081.0,
+          "diff_mwh": 2782.0,
+          "shape_corr": 0.886
+        },
+        "wind": {
+          "uc_mwh": 1030.0,
+          "measured_mwh": 918.0,
+          "diff_mwh": 112.0,
+          "shape_corr": 0.315
+        },
+        "pumped_hydro": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 347.0,
+          "diff_mwh": -347.0,
+          "shape_corr": null
+        },
+        "battery": {
+          "uc_mwh": 37.2,
+          "measured_mwh": 0.0,
+          "diff_mwh": 37.2,
+          "shape_corr": null
+        }
+      },
+      "share_l1_pp": 33.06,
+      "curtailment_mwh": {
+        "solar": 0.0,
+        "wind": 0.0
+      }
+    },
+    "shikoku": {
+      "company": "shikoku",
+      "demand_measured_mwh": 94018.0,
+      "per_fuel": {
+        "nuclear": {
+          "uc_mwh": 21360.0,
+          "measured_mwh": 20857.0,
+          "diff_mwh": 503.0,
+          "shape_corr": null
+        },
+        "lng": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 7972.0,
+          "diff_mwh": -7972.0,
+          "shape_corr": null
+        },
+        "coal": {
+          "uc_mwh": 82944.0,
+          "measured_mwh": 56566.5,
+          "diff_mwh": 26377.5,
+          "shape_corr": null
+        },
+        "oil": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 6054.5,
+          "diff_mwh": -6054.5,
+          "shape_corr": null
+        },
+        "hydro": {
+          "uc_mwh": 10377.6,
+          "measured_mwh": 8315.0,
+          "diff_mwh": 2062.6,
+          "shape_corr": null
+        },
+        "biomass": {
+          "uc_mwh": 4560.0,
+          "measured_mwh": 6964.0,
+          "diff_mwh": -2404.0,
+          "shape_corr": null
+        },
+        "solar": {
+          "uc_mwh": 8963.4,
+          "measured_mwh": 16931.0,
+          "diff_mwh": -7967.6,
+          "shape_corr": 0.988
+        },
+        "wind": {
+          "uc_mwh": 1707.6,
+          "measured_mwh": 228.0,
+          "diff_mwh": 1479.6,
+          "shape_corr": 0.462
+        },
+        "battery": {
+          "uc_mwh": 315.3,
+          "measured_mwh": -18.0,
+          "diff_mwh": 333.3,
+          "shape_corr": 0.159
+        }
+      },
+      "share_l1_pp": 41.33,
+      "curtailment_mwh": {
+        "solar": 0.0,
+        "wind": 0.0
+      }
+    }
+  },
+  "summary": {
+    "l1_pp_by_region": {
+      "hokkaido": 43.98,
+      "tohoku": 69.71,
+      "tokyo": 12.66,
+      "hokuriku": 33.06,
+      "shikoku": 41.33
+    },
+    "l1_pp_mean": 40.15
+  }
+}

--- a/scripts/uc_validate.py
+++ b/scripts/uc_validate.py
@@ -1,0 +1,230 @@
+"""UC検証 Phase A-1 — 代表日のUC解を発電実績（nas03）と地域×燃料で突合する。
+
+docs/UC_VALIDATION_PLAN.md §2 の最初の実装。fy2025r1 の代表日
+（2025-08-06、実測需要で構築済み）のUC解を、同日の各社「エリア需給実績」
+（電源種別・30分値、nas03/PWS_DB）と比較する — **実日付・地域別・
+燃料分解あり**の最初の検証。
+
+使い方:
+    AJGRID_NAS03_ROOT="ssh://pwslab@100.102.148.23/volume1/PWS_DB" \\
+      python3 scripts/uc_validate.py --scenario fy2025r1 --date 2025-08-06 \\
+      --companies hokkaido,tohoku,tepco,hokuriku,shikoku
+
+出力: docs/reports/uc_validation_<scenario>_<date>.json + uc_runs(kind=validation)
+
+比較の語彙（UC→実績、開示付き）:
+- nuclear/lng/coal/hydro/geothermal/biomass/pumped_hydro/battery は直接対応
+- UC oil ↔ 実績 火力(石油)+火力(その他)（区分差は開示）
+- UC solar/wind（シナリオ参照値の地域配分）↔ 実績 太陽光/風力発電実績
+  （抑制量は別記）
+- 実績「水力」は一般水力（揚水は別列）= UC hydro と整合
+"""
+
+import argparse
+import datetime as _dt
+import json
+import os
+import subprocess
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+os.chdir(os.path.join(os.path.dirname(__file__), ".."))
+
+from src.dataspace import DataSpace  # noqa: E402
+from src.dataspace.connectors.nas03 import COMPANY_TO_REGION  # noqa: E402
+from src.uc.pf_injection import uc_snapshot  # noqa: E402
+from src.uc.scenario import build_national_scenario  # noqa: E402
+from src.uc.solver import solve_uc  # noqa: E402
+
+# UC燃料 → 実績側キー（集計対応。値はリスト=実績側の合算）
+UC_TO_MEASURED = {
+    "nuclear": ["nuclear"],
+    "lng": ["lng"],
+    "coal": ["coal"],
+    "oil": ["oil", "thermal_other"],   # 区分差: 実績「火力(その他)」を石油側へ
+    "hydro": ["hydro"],
+    "geothermal": ["geothermal"],
+    "biomass": ["biomass"],
+    "solar": ["solar"],
+    "wind": ["wind"],
+    "pumped_hydro": ["pumped_hydro"],
+    "battery": ["battery"],
+}
+
+
+def _git_head() -> str:
+    try:
+        return subprocess.run(["git", "rev-parse", "--short", "HEAD"],
+                              capture_output=True, text=True,
+                              check=True).stdout.strip()
+    except Exception:
+        return "unknown"
+
+
+def uc_region_fuel_24h(scn, uc, region) -> dict:
+    """UC解の地域×燃料×24h MW（thermal+storageはschedules、RE/RoRはシナリオ参照）。"""
+    out = {}
+    for t in range(24):
+        snap = uc_snapshot(uc, scn.generators, t, region=region)
+        for fuel, mw in snap.items():
+            out.setdefault(fuel, [0.0] * 24)[t] += mw
+    # UCは純需要で解く — solar/wind/RoR水力は需要から控除済みなので
+    # シナリオ参照系列を「UC側の供給」として復元する
+    if region in scn.solar_gen_r:
+        out["solar"] = [float(v) for v in scn.solar_gen_r[region]]
+    if region in scn.wind_gen_r:
+        out["wind"] = [float(v) for v in scn.wind_gen_r[region]]
+    if scn.hydro_ror_gen_r and region in scn.hydro_ror_gen_r:
+        ror = scn.hydro_ror_gen_r[region]
+        base = out.get("hydro", [0.0] * 24)
+        out["hydro"] = [float(b) + float(r) for b, r in zip(base, ror)]
+    return out
+
+
+def measured_region_fuel_24h(rows, date_str) -> dict:
+    """実績30分値（MW平均）→ 1時間平均×24hの燃料別系列。"""
+    by_fuel: dict = {}
+    cnt: dict = {}
+    for rec in rows:
+        # dt例: "2025/8/6 0:30" / "2025/08/06 00:30"
+        try:
+            hh = int(rec["dt"].split()[1].split(":")[0])
+        except (IndexError, ValueError):
+            continue
+        for fuel, v in rec.items():
+            if fuel == "dt" or not isinstance(v, (int, float)):
+                continue
+            by_fuel.setdefault(fuel, [0.0] * 24)[hh] += v
+            cnt.setdefault(fuel, [0] * 24)[hh] += 1
+    for fuel, series in by_fuel.items():
+        c = cnt[fuel]
+        by_fuel[fuel] = [s / c[h] if c[h] else 0.0
+                         for h, s in enumerate(series)]
+    return by_fuel
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--scenario", default="fy2025r1")
+    ap.add_argument("--date", default="2025-08-06",
+                    help="検証日（シナリオの代表日と一致させる）")
+    ap.add_argument("--companies",
+                    default="hokkaido,tohoku,tepco,hokuriku,shikoku",
+                    help="新形式在庫のある会社（カンマ区切り）")
+    ap.add_argument("--force-fetch", action="store_true",
+                    help="DataSpaceキャッシュを無視して実績を再取得")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+    companies = [c.strip() for c in args.companies.split(",") if c.strip()]
+    month = args.date.replace("-", "")[:6]
+
+    # ── 1. UC ──
+    print(f"UC求解中... ({args.scenario})")
+    scn = build_national_scenario(scenario=args.scenario)
+    uc = solve_uc(scn.to_uc_parameters())
+    print(f"  {uc.status}")
+    if not uc.is_optimal:
+        return 1
+
+    # ── 2. 実績取得（必要月×社のみ、DataSpace経由=キャッシュ+provenance） ──
+    ds = DataSpace()
+    report_regions = {}
+    l1_rows = []
+    for company in companies:
+        region = COMPANY_TO_REGION[company]
+        print(f"実績取得: {company} ({region}) {month} ...")
+        meas_raw = ds.fetch("nas03_generation_records",
+                            {"company": company, "month": month,
+                             "date": args.date},
+                            force=args.force_fetch)
+        meas = measured_region_fuel_24h(meas_raw["rows"], args.date)
+        ucr = uc_region_fuel_24h(scn, uc, region)
+
+        fuels = sorted(set(UC_TO_MEASURED) & (set(ucr) | {"solar", "wind"}))
+        per_fuel = {}
+        for fuel in UC_TO_MEASURED:
+            uc_mwh = float(np.sum(ucr.get(fuel, [])))
+            m_mwh = float(sum(np.sum(meas.get(k, []))
+                              for k in UC_TO_MEASURED[fuel]))
+            if uc_mwh < 1 and m_mwh < 1:
+                continue
+            # 形状相関（両方に24h系列があり分散が0でない場合）
+            corr = None
+            us = np.array(ucr.get(fuel, [0.0] * 24))
+            ms = np.array([sum(meas.get(k, [0.0] * 24)[h]
+                               for k in UC_TO_MEASURED[fuel])
+                           for h in range(24)])
+            if us.std() > 1e-6 and ms.std() > 1e-6:
+                corr = round(float(np.corrcoef(us, ms)[0, 1]), 3)
+            per_fuel[fuel] = {
+                "uc_mwh": round(uc_mwh, 1),
+                "measured_mwh": round(m_mwh, 1),
+                "diff_mwh": round(uc_mwh - m_mwh, 1),
+                "shape_corr": corr,
+            }
+        uc_tot = sum(v["uc_mwh"] for v in per_fuel.values())
+        m_tot = sum(v["measured_mwh"] for v in per_fuel.values())
+        l1_pp = (sum(abs(v["uc_mwh"] / uc_tot - v["measured_mwh"] / m_tot)
+                     for v in per_fuel.values()) * 100
+                 if uc_tot > 0 and m_tot > 0 else None)
+        report_regions[region] = {
+            "company": company,
+            "demand_measured_mwh": round(
+                float(np.sum(meas.get("demand", []))), 1),
+            "per_fuel": per_fuel,
+            "share_l1_pp": round(l1_pp, 2) if l1_pp is not None else None,
+            "curtailment_mwh": {
+                "solar": round(float(np.sum(meas.get("solar_curtailed", []))), 1),
+                "wind": round(float(np.sum(meas.get("wind_curtailed", []))), 1),
+            },
+        }
+        l1_rows.append((region, l1_pp))
+        print(f"  {region}: L1 {l1_pp:.1f}pp" if l1_pp is not None
+              else f"  {region}: L1 n/a")
+
+    report = {
+        "meta": {
+            "date": _dt.date.today().isoformat(),
+            "git_head": _git_head(),
+            "scenario": args.scenario,
+            "validation_date": args.date,
+            "companies": companies,
+            "vocabulary_notes": [
+                "UC oil = 実績 火力(石油)+火力(その他)（区分差の開示）",
+                "UC solar/wind はシナリオ参照値（fy2025r1はFY2023容量踏襲="
+                "FY2025導入増未較正のバイアスをここで実測する）",
+                "実績は30分MW平均→1h平均、UCは1h値",
+            ],
+        },
+        "regions": report_regions,
+        "summary": {
+            "l1_pp_by_region": {r: round(v, 2) for r, v in l1_rows
+                                if v is not None},
+            "l1_pp_mean": round(
+                float(np.mean([v for _, v in l1_rows if v is not None])), 2)
+            if any(v is not None for _, v in l1_rows) else None,
+        },
+    }
+    out = args.out or (f"docs/reports/uc_validation_{args.scenario}_"
+                       f"{args.date}.json")
+    with open(out, "w") as f:
+        json.dump(report, f, ensure_ascii=False, indent=2)
+    print(f"Saved: {out}")
+    print(f"地域別L1: {report['summary']['l1_pp_by_region']} "
+          f"(平均 {report['summary']['l1_pp_mean']}pp)")
+
+    from src.uc.run_recorder import record_run
+    record_run(out, kind="validation", run_date=report["meta"]["date"],
+               git_head=report["meta"]["git_head"],
+               scenario_id=args.scenario,
+               status="ok",
+               l1_total_pp=report["summary"]["l1_pp_mean"],
+               summary_json=json.dumps(
+                   report["summary"]["l1_pp_by_region"], ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/dataspace/connectors/nas03.py
+++ b/src/dataspace/connectors/nas03.py
@@ -1,0 +1,185 @@
+"""nas03 (PWS_DB) コネクタ — エリア需給実績（電源種別・30分/1時間値）。
+
+研究室NAS pws-nas03 の `/volume1/PWS_DB/demand_raw/{company}/` から
+**必要な月のCSVだけ** を取得し、正規形（時刻×正規燃料キーのMW平均）で返す
+（zero-copy原則 / docs/UC_VALIDATION_PLAN.md §2.2）。
+
+所在は ``AJGRID_NAS03_ROOT``（契約カタログの env: 参照）:
+- ``ssh://user@host/path`` — ssh cat で取得（既定。研究室Tailscale経由）
+- ローカルパス — pws-gpu3060 の /mnt/nas03 等のマウント済み環境
+
+形式（2026-06-12 実地調査）:
+- 新形式（2024-04〜、5社で互換確認: hokkaido/tohoku/tepco/hokuriku/shikoku）:
+  ``DATE,TIME,エリア需要,原子力,火力(LNG),火力(石炭),火力(石油),火力(その他),
+  [火力出力制御量,]水力,地熱,バイオマス,[バイオマス出力制御量,]太陽光発電実績,
+  太陽光出力制御量,風力発電実績,風力出力制御量,揚水,蓄電池,連系線,その他,合計``
+  （hokkaido は制御量2列が多い → 列名マップで吸収。CP932・30分値MW平均）
+- 旧形式（〜2024-03）は火力が合算列 — Phase B で対応（PLAN §3）
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+from typing import Any, Dict
+
+from src.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# CSV列名（部分一致） → 正規燃料キー
+_FUEL_COLUMNS = {
+    "エリア需要": "demand",
+    "原子力": "nuclear",
+    "火力(LNG)": "lng",
+    "火力(石炭)": "coal",
+    "火力(石油)": "oil",
+    "火力(その他)": "thermal_other",
+    "水力": "hydro",
+    "地熱": "geothermal",
+    "バイオマス": "biomass",
+    "太陽光発電実績": "solar",
+    "太陽光出力制御量": "solar_curtailed",
+    "風力発電実績": "wind",
+    "風力出力制御量": "wind_curtailed",
+    "揚水": "pumped_hydro",
+    "蓄電池": "battery",
+    "連系線": "interconnector",
+    "その他": "other",
+}
+# 「バイオマス出力制御量」等が「バイオマス」に部分一致しないよう長い順に照合
+_FUEL_KEYS_ORDERED = sorted(_FUEL_COLUMNS, key=len, reverse=True)
+
+# PWS_DB の会社ディレクトリ名 → AGJ地域キー
+COMPANY_TO_REGION = {
+    "hokkaido": "hokkaido", "tohoku": "tohoku", "tepco": "tokyo",
+    "chubu": "chubu", "hokuriku": "hokuriku", "kansai": "kansai",
+    "chugoku": "chugoku", "shikoku": "shikoku", "kyushu": "kyushu",
+    "okinawa": "okinawa",
+}
+
+
+def _read_remote(root: str, relpath: str) -> bytes:
+    """AJGRID_NAS03_ROOT の形式に応じて CSV バイト列を取得する。"""
+    if root.startswith("ssh://"):
+        rest = root[len("ssh://"):]
+        host, _, base = rest.partition("/")
+        result = subprocess.run(
+            ["ssh", "-o", "ConnectTimeout=15", "-o", "BatchMode=yes",
+             host, f"cat /{base}/{relpath}"],
+            capture_output=True, timeout=120,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"nas03 ssh cat failed ({relpath}): "
+                f"{result.stderr.decode(errors='replace')[:200]}")
+        return result.stdout
+    path = os.path.join(root, relpath)
+    with open(path, "rb") as f:
+        return f.read()
+
+
+class Nas03Connector:
+    """query:
+        company: PWS_DB の会社キー（'hokuriku' 等、COMPANY_TO_REGION参照）
+        month: 'YYYYMM'（新形式の在庫がある月）
+        date: 省略可 'YYYY-MM-DD' — 指定日のみに絞る
+    返却: {"region", "company", "month", "rows": [{"dt", fuel: mw, ...}...],
+           "fuels": [...], "n_rows": int}
+    （30分値MW平均の行リスト。再配布可能な集約・正規化済み形式）
+    """
+
+    def fetch(self, query: Dict[str, Any], contract) -> Any:
+        import csv as _csv
+
+        company = str(query["company"])
+        month = str(query["month"])
+        if company not in COMPANY_TO_REGION:
+            raise ValueError(f"nas03: unknown company '{company}'")
+        root = contract.resolve_location()
+        if not root:
+            raise RuntimeError(
+                "nas03の所在が未設定 — 環境変数 AJGRID_NAS03_ROOT を設定して"
+                "ください（例: ssh://pwslab@100.102.148.23/volume1/PWS_DB、"
+                "マウント済み環境では /mnt/nas03）。暗黙のフォールバックは"
+                "しない方針（DATA_SPACE.md §4）")
+        raw = _read_remote(root, f"demand_raw/{company}/{month}.csv")
+        # tepco月次はUTF-8-SIG、他社はCP932 — 「エリア需要」が読める方を採用
+        # （CP932固定だとtepcoの列名が化けてdemand列が消え全行棄却になる）
+        text = None
+        for enc in ("utf-8-sig", "cp932"):
+            try:
+                cand = raw.decode(enc)
+            except UnicodeDecodeError:
+                continue
+            if "エリア需要" in cand:
+                text = cand
+                break
+        if text is None:
+            text = raw.decode("cp932", errors="replace")
+
+        reader = _csv.reader(io.StringIO(text))
+        rows_in = [r for r in reader if r]
+        h_idx = next((i for i, r in enumerate(rows_in)
+                      if r and r[0].strip() == "DATE"), None)
+        if h_idx is None:
+            raise RuntimeError(
+                f"nas03: {company}/{month}.csv に新形式ヘッダ(DATE,TIME,…)が"
+                f"見つからない — 旧形式（火力合算）はPhase B対応")
+        header = rows_in[h_idx]
+        col_map: Dict[int, str] = {}
+        for i, col in enumerate(header):
+            c = col.strip()
+            for key in _FUEL_KEYS_ORDERED:
+                if key in c:
+                    # 「バイオマス出力制御量」等、キー側に無い制御量列が
+                    # 本体キー（バイオマス）へ部分一致して値を上書きする
+                    # のを防ぐ（hokkaido変種で実害を確認）
+                    if "出力制御量" in c and "出力制御量" not in key:
+                        break
+                    col_map[i] = _FUEL_COLUMNS[key]
+                    break
+
+        want_date = str(query.get("date", "")).replace("-", "/")
+        # "2025/08/06" と "2025/8/6" の両表記に対応
+        want_alt = None
+        if want_date:
+            y, m, d = want_date.split("/")
+            want_alt = f"{y}/{int(m)}/{int(d)}"
+
+        out_rows = []
+        for r in rows_in[h_idx + 1:]:
+            if len(r) < 3 or not r[0].strip():
+                continue
+            date_s = r[0].strip()
+            if want_date and date_s not in (want_date, want_alt):
+                continue
+            rec: Dict[str, Any] = {"dt": f"{date_s} {r[1].strip()}"}
+            ok = False
+            for i, fuel in col_map.items():
+                if i >= len(r):
+                    continue
+                v = r[i].strip().replace(",", "")
+                if v in ("", "－", "-"):
+                    continue
+                try:
+                    rec[fuel] = float(v)
+                    ok = True
+                except ValueError:
+                    continue
+            if ok and "demand" in rec:
+                out_rows.append(rec)
+
+        fuels = sorted({k for rec in out_rows for k in rec if k != "dt"})
+        logger.info("nas03 fetch %s/%s: %d rows, fuels=%s",
+                    company, month, len(out_rows), fuels)
+        return {
+            "region": COMPANY_TO_REGION[company],
+            "company": company,
+            "month": month,
+            "date": str(query.get("date", "")) or None,
+            "n_rows": len(out_rows),
+            "fuels": fuels,
+            "rows": out_rows,
+        }

--- a/src/dataspace/registry.py
+++ b/src/dataspace/registry.py
@@ -122,6 +122,9 @@ class DataSpace:
         if contract.connector == "msm":
             from src.dataspace.connectors.msm import MSMConnector
             return MSMConnector()
+        if contract.connector == "nas03":
+            from src.dataspace.connectors.nas03 import Nas03Connector
+            return Nas03Connector()
         raise ValueError(f"unknown connector '{contract.connector}'")
 
     def fetch(

--- a/src/uc/scenario.py
+++ b/src/uc/scenario.py
@@ -1139,6 +1139,32 @@ def build_national_scenario(
         if r in ror_cf_r
     }
 
+    # 代表日（実測needs）の月が分かる場合はRE/RoRへ季節係数を適用する。
+    # 24h断面が年平均CFのままだと、弱風期（8月 wind_month_mult=0.70）に
+    # 風力が実績の~3倍になることを検証ループで実測（uc_validate 2025-08-06、
+    # tohoku UC 650MW平均 vs 実績213MW）。年間経路 build_annual_profiles と
+    # 同じ月係数を使い、断面と年間の季節性を整合させる。
+    rep_day = str((config.demand_profile_ref or {}).get(
+        "representative_day", ""))
+    try:
+        rep_month = int(rep_day.split("-")[1]) if rep_day else None
+    except (IndexError, ValueError):
+        rep_month = None
+    if rep_month is not None:
+        ann = (config.raw or {}).get("annual") or {}
+        sm = ann.get("solar_month_mult")
+        wm = ann.get("wind_month_mult")
+        rm = ann.get("hydro_ror_month_mult")
+        if sm:
+            solar_gen_r = {r: v * float(sm[rep_month - 1])
+                           for r, v in solar_gen_r.items()}
+        if wm:
+            wind_gen_r = {r: v * float(wm[rep_month - 1])
+                          for r, v in wind_gen_r.items()}
+        if rm:
+            hydro_ror_gen_r = {r: v * float(rm[rep_month - 1])
+                               for r, v in hydro_ror_gen_r.items()}
+
     return NationalScenario(
         generators=gens,
         interconnections=ics,

--- a/tests/test_nas03_connector.py
+++ b/tests/test_nas03_connector.py
@@ -1,0 +1,96 @@
+"""Tests for nas03 connector — エリア需給実績CSVの新形式パーサ。
+
+実フォーマット（2026-06-12実地調査）を合成CSVで再現し、列名マップ・
+hokkaido変種（制御量+2列）・日付フィルタ・欠測の扱いを検証する。
+"""
+
+import pytest
+
+from src.dataspace.connectors.nas03 import COMPANY_TO_REGION, Nas03Connector
+
+
+class _FakeContract:
+    def __init__(self, root):
+        self._root = root
+
+    def resolve_location(self):
+        return self._root
+
+
+CSV_STD = """単位[MW平均],,,供給力,,,,,,,,,,,,,,,,
+DATE,TIME,エリア需要,原子力,火力(LNG),火力(石炭),火力(石油),火力(その他),水力,地熱,バイオマス,太陽光発電実績,太陽光出力制御量,風力発電実績,風力出力制御量,揚水,蓄電池,連系線,その他,合計
+2025/8/6,0:00,2315,0,124,788,0,15,1308,0,68,0,0,3,0,0,0,-50,59,2315
+2025/8/6,0:30,2289,0,120,743,0,15,1324,0,66,0,0,3,0,0,0,-38,57,2289
+2025/8/7,0:00,2400,0,130,800,0,15,1300,0,70,0,0,3,0,0,0,-40,60,2400
+"""
+
+# hokkaido変種: 火力出力制御量・バイオマス出力制御量の2列が追加
+CSV_HOKKAIDO = """単位[MW平均],,,供給力,,,,,,,,,,,,,,,,,,
+DATE,TIME,エリア需要,原子力,火力(LNG),火力(石炭),火力(石油),火力(その他),火力出力制御量,水力,地熱,バイオマス,バイオマス出力制御量,太陽光発電実績,太陽光出力制御量,風力発電実績,風力出力制御量,揚水,蓄電池,連系線,その他,合計
+2025/8/6,0:00,2800,0,500,900,10,20,0,400,30,100,0,0,0,150,5,-20,10,695,0,2800
+"""
+
+
+@pytest.fixture
+def nas(tmp_path):
+    """ローカルパス所在のフェイクPWS_DBを組み立てる。"""
+    for company, text in (("hokuriku", CSV_STD), ("hokkaido", CSV_HOKKAIDO)):
+        d = tmp_path / "demand_raw" / company
+        d.mkdir(parents=True)
+        (d / "202508.csv").write_bytes(text.encode("cp932"))
+    # tepco実態: 月次はUTF-8-SIG（CP932固定読みだと列名が化ける）
+    d = tmp_path / "demand_raw" / "tepco"
+    d.mkdir(parents=True)
+    (d / "202508.csv").write_bytes(CSV_STD.encode("utf-8-sig"))
+    return _FakeContract(str(tmp_path))
+
+
+class TestParser:
+    def test_standard_format_and_date_filter(self, nas):
+        out = Nas03Connector().fetch(
+            {"company": "hokuriku", "month": "202508", "date": "2025-08-06"},
+            nas)
+        assert out["region"] == "hokuriku"
+        assert out["n_rows"] == 2          # 8/7の行は除外
+        r0 = out["rows"][0]
+        assert r0["demand"] == pytest.approx(2315.0)
+        assert r0["coal"] == pytest.approx(788.0)
+        assert r0["hydro"] == pytest.approx(1308.0)
+        assert r0["interconnector"] == pytest.approx(-50.0)
+        # 「その他」と「火力(その他)」が区別される
+        assert r0["other"] == pytest.approx(59.0)
+        assert r0["thermal_other"] == pytest.approx(15.0)
+
+    def test_hokkaido_extra_columns(self, nas):
+        out = Nas03Connector().fetch(
+            {"company": "hokkaido", "month": "202508"}, nas)
+        r0 = out["rows"][0]
+        # 制御量列のズレに惑わされず本体列が正しく取れる
+        assert r0["hydro"] == pytest.approx(400.0)
+        assert r0["biomass"] == pytest.approx(100.0)
+        assert r0["wind"] == pytest.approx(150.0)
+        assert r0["wind_curtailed"] == pytest.approx(5.0)
+
+    def test_tepco_utf8_sig(self, nas):
+        out = Nas03Connector().fetch(
+            {"company": "tepco", "month": "202508", "date": "2025-08-06"},
+            nas)
+        assert out["region"] == "tokyo"
+        assert out["n_rows"] == 2
+        assert out["rows"][0]["demand"] == pytest.approx(2315.0)
+
+    def test_unknown_company_raises(self, nas):
+        with pytest.raises(ValueError, match="unknown company"):
+            Nas03Connector().fetch({"company": "nowhere", "month": "202508"},
+                                   nas)
+
+    def test_missing_location_guides(self):
+        with pytest.raises(RuntimeError, match="AJGRID_NAS03_ROOT"):
+            Nas03Connector().fetch(
+                {"company": "hokuriku", "month": "202508"},
+                _FakeContract(None))
+
+
+def test_company_region_map_covers_10():
+    assert len(COMPANY_TO_REGION) == 10
+    assert COMPANY_TO_REGION["tepco"] == "tokyo"


### PR DESCRIPTION
## Summary

/goal「計画で示したことが実現でき、精度を担保すること」の実装第一弾 — **検証ループが実データで回り始めました**（台帳⑰）。

### 実装
- **nas03コネクタ**: エリア需給実績（電源種別・30分値）をssh zero-copyで月単位取得。hokkaido変種（+2列）を列名マップで吸収、制御量列の上書きバグ修正、**tepcoのUTF-8-SIG対応**（CP932固定だと列名が化けて全行棄却=tokyoが空に見えた）
- **uc_validate.py**: 代表日2025-08-06のUC解 vs 5社実績の地域×燃料突合（日エネルギー/シェアL1/形状相関/抑制量）、uc_runs記録、--force-fetch

### ベースラインと1巡目の知見
- L1: **tokyo 12.7pp** / hokuriku 33.1 / shikoku 41.3 / hokkaido 44.0 / tohoku 69.7（平均40.2pp）
- **hokuriku coal 61.2 vs 62.0 GWh/日** — 容量パッチ（七尾大田・敦賀）が実績と整合することを実測で立証
- solar形状相関0.89-0.96 — 時間形状は正確、バイアスは量側
- 自己改善1巡目: 24h断面にRE月係数が未適用（8月のtohoku windが3倍）→適用。**L1はほぼ不変（40.8pp）= 残差はcoal/LNGスワップ（経済停止、タスク#12）に集約**という構造を確定

## Test plan
- [x] コネクタ6+dataspace 9+scenario 39 passed
- [x] 実データ5社で検証実行・レポートJSON生成・uc_runs記録

🤖 Generated with [Claude Code](https://claude.com/claude-code)