### PR TITLE
UC 20: weather-normalized validation — Sunday gap was weather, not operations (mean 32.6pp)

### DIFF
--- a/docs/reports/IMPROVEMENT_LOG.md
+++ b/docs/reports/IMPROVEMENT_LOG.md
@@ -131,6 +131,22 @@ KPIは `ajgrid validate --topology --all --solve` の計測値
 <!-- ── UC改善シリーズ（worktree uc-improvements） ── -->
 
 
+## 2026-06-12 — **Fable 5** — UC改善⑳: 天気正規化検証（--re-actuals）— tokyo日曜悪化の真因は天気
+
+- **tokyo日曜52.6ppの分解**: 主因は休日運用ではなく**天気** — 8/10のsolar実績
+  16.0GWh vs UC想定78.1GWh（雨曇の日曜、形状相関0.968=形は完璧で量1/5）。
+  太陽光不足分が実績側で lng+109/oil+42GWh の追い焚きとなりUCと乖離
+- **--re-actuals**（uc_validate）: 検証地域のsolar/windを**当日実績系列で置換**
+  してUCを解く=天気を所与にして**運用だけを比較**する検証モード
+  （NationalScenario.net_demand_rはpropertyなので置換だけで純需要も追従）
+- **結果（8/10）**: tokyo 52.6→**28.9pp** / hokuriku 21.0 / shikoku 21.8 /
+  平均36.6→**32.6pp**。残るtokyo 28.9はcoal+64GWh（休日のcoal抑制を
+  UCが知らない=経済停止の残り）等の純粋な運用差
+- 教訓: **単日検証は天気正規化が必須**（手法の進化）。hokkaidoは31.7→39.7と
+  悪化=実績RE置換で別の前提差（wind実績の少なさ→coal流れ込み）が露出
+- 残差更新: ①coal休日抑制（tokyo+64GWh、全国coal設備過大と同根の可能性）
+  ②hokkaidoの前提差 ③地熱個別機 ④kansai旧形式（Phase B）
+
 ## 2026-06-12 — **Fable 5** — UC改善⑲: 効率ティルト — 経済停止の決定論表現（人工CF上限なし）
 
 - **apply_fuel_cost_tilt**(`src/uc/scenario.py`): 同一燃料グループへ実在の

--- a/docs/reports/uc_validation_fy2025r1_2025-08-10_reactuals.json
+++ b/docs/reports/uc_validation_fy2025r1_2025-08-10_reactuals.json
@@ -1,0 +1,382 @@
+{
+  "meta": {
+    "date": "2026-06-12",
+    "git_head": "6271e40",
+    "scenario": "fy2025r1",
+    "validation_date": "2025-08-10",
+    "re_actuals": true,
+    "companies": [
+      "hokkaido",
+      "tohoku",
+      "tepco",
+      "hokuriku",
+      "shikoku"
+    ],
+    "vocabulary_notes": [
+      "UC oil = 実績 火力(石油)+火力(その他)（区分差の開示）",
+      "UC solar/wind はシナリオ参照値（fy2025r1はFY2023容量踏襲=FY2025導入増未較正のバイアスをここで実測する）",
+      "実績は30分MW平均→1h平均、UCは1h値"
+    ]
+  },
+  "regions": {
+    "hokkaido": {
+      "company": "hokkaido",
+      "demand_measured_mwh": 71356.0,
+      "per_fuel": {
+        "lng": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 393.5,
+          "diff_mwh": -393.5,
+          "shape_corr": null
+        },
+        "coal": {
+          "uc_mwh": 49588.6,
+          "measured_mwh": 28418.5,
+          "diff_mwh": 21170.1,
+          "shape_corr": 0.424
+        },
+        "oil": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 10358.5,
+          "diff_mwh": -10358.5,
+          "shape_corr": null
+        },
+        "hydro": {
+          "uc_mwh": 20040.0,
+          "measured_mwh": 12597.5,
+          "diff_mwh": 7442.5,
+          "shape_corr": null
+        },
+        "geothermal": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 24.0,
+          "diff_mwh": -24.0,
+          "shape_corr": null
+        },
+        "biomass": {
+          "uc_mwh": 11400.0,
+          "measured_mwh": 6412.5,
+          "diff_mwh": 4987.5,
+          "shape_corr": null
+        },
+        "solar": {
+          "uc_mwh": 10349.5,
+          "measured_mwh": 10349.5,
+          "diff_mwh": 0.0,
+          "shape_corr": 1.0
+        },
+        "wind": {
+          "uc_mwh": 1542.0,
+          "measured_mwh": 1542.0,
+          "diff_mwh": 0.0,
+          "shape_corr": 1.0
+        },
+        "pumped_hydro": {
+          "uc_mwh": 263.2,
+          "measured_mwh": 339.0,
+          "diff_mwh": -75.8,
+          "shape_corr": 0.643
+        },
+        "battery": {
+          "uc_mwh": 1141.7,
+          "measured_mwh": -187.5,
+          "diff_mwh": 1329.2,
+          "shape_corr": 0.154
+        }
+      },
+      "share_l1_pp": 39.73,
+      "curtailment_mwh": {
+        "solar": 0.0,
+        "wind": 0.0
+      }
+    },
+    "tohoku": {
+      "company": "tohoku",
+      "demand_measured_mwh": 180091.0,
+      "per_fuel": {
+        "nuclear": {
+          "uc_mwh": 19800.0,
+          "measured_mwh": 18884.0,
+          "diff_mwh": 916.0,
+          "shape_corr": null
+        },
+        "lng": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 55207.0,
+          "diff_mwh": -55207.0,
+          "shape_corr": null
+        },
+        "coal": {
+          "uc_mwh": 206626.7,
+          "measured_mwh": 148139.5,
+          "diff_mwh": 58487.2,
+          "shape_corr": 0.516
+        },
+        "oil": {
+          "uc_mwh": 431.4,
+          "measured_mwh": 7330.0,
+          "diff_mwh": -6898.6,
+          "shape_corr": 0.397
+        },
+        "hydro": {
+          "uc_mwh": 27710.4,
+          "measured_mwh": 25503.5,
+          "diff_mwh": 2206.9,
+          "shape_corr": null
+        },
+        "geothermal": {
+          "uc_mwh": 17503.2,
+          "measured_mwh": 3465.5,
+          "diff_mwh": 14037.7,
+          "shape_corr": null
+        },
+        "biomass": {
+          "uc_mwh": 5337.6,
+          "measured_mwh": 18544.0,
+          "diff_mwh": -13206.4,
+          "shape_corr": null
+        },
+        "solar": {
+          "uc_mwh": 12994.5,
+          "measured_mwh": 12994.5,
+          "diff_mwh": 0.0,
+          "shape_corr": 1.0
+        },
+        "wind": {
+          "uc_mwh": 2184.0,
+          "measured_mwh": 2184.0,
+          "diff_mwh": 0.0,
+          "shape_corr": 1.0
+        },
+        "pumped_hydro": {
+          "uc_mwh": 1140.5,
+          "measured_mwh": 14.0,
+          "diff_mwh": 1126.5,
+          "shape_corr": -0.231
+        },
+        "battery": {
+          "uc_mwh": 800.0,
+          "measured_mwh": -35.0,
+          "diff_mwh": 835.0,
+          "shape_corr": 0.215
+        }
+      },
+      "share_l1_pp": 51.65,
+      "curtailment_mwh": {
+        "solar": 0.0,
+        "wind": 0.0
+      }
+    },
+    "tokyo": {
+      "company": "tepco",
+      "demand_measured_mwh": 710607.0,
+      "per_fuel": {
+        "lng": {
+          "uc_mwh": 239721.8,
+          "measured_mwh": 282149.0,
+          "diff_mwh": -42427.2,
+          "shape_corr": 0.966
+        },
+        "coal": {
+          "uc_mwh": 238128.0,
+          "measured_mwh": 174111.5,
+          "diff_mwh": 64016.5,
+          "shape_corr": null
+        },
+        "oil": {
+          "uc_mwh": 2498.4,
+          "measured_mwh": 47953.0,
+          "diff_mwh": -45454.6,
+          "shape_corr": -0.185
+        },
+        "hydro": {
+          "uc_mwh": 36331.2,
+          "measured_mwh": 35577.5,
+          "diff_mwh": 753.7,
+          "shape_corr": null
+        },
+        "biomass": {
+          "uc_mwh": 12763.2,
+          "measured_mwh": 10267.5,
+          "diff_mwh": 2495.7,
+          "shape_corr": null
+        },
+        "solar": {
+          "uc_mwh": 16035.5,
+          "measured_mwh": 16035.5,
+          "diff_mwh": 0.0,
+          "shape_corr": 1.0
+        },
+        "wind": {
+          "uc_mwh": 3958.0,
+          "measured_mwh": 3958.0,
+          "diff_mwh": 0.0,
+          "shape_corr": 1.0
+        },
+        "pumped_hydro": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 8724.0,
+          "diff_mwh": -8724.0,
+          "shape_corr": null
+        },
+        "battery": {
+          "uc_mwh": 186.0,
+          "measured_mwh": 56.5,
+          "diff_mwh": 129.5,
+          "shape_corr": 0.551
+        }
+      },
+      "share_l1_pp": 28.93,
+      "curtailment_mwh": {
+        "solar": 0.0,
+        "wind": 0.0
+      }
+    },
+    "hokuriku": {
+      "company": "hokuriku",
+      "demand_measured_mwh": 58638.0,
+      "per_fuel": {
+        "lng": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 2936.5,
+          "diff_mwh": -2936.5,
+          "shape_corr": null
+        },
+        "coal": {
+          "uc_mwh": 58314.9,
+          "measured_mwh": 38765.5,
+          "diff_mwh": 19549.4,
+          "shape_corr": 0.534
+        },
+        "oil": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 40.0,
+          "diff_mwh": -40.0,
+          "shape_corr": null
+        },
+        "hydro": {
+          "uc_mwh": 24765.6,
+          "measured_mwh": 21460.0,
+          "diff_mwh": 3305.6,
+          "shape_corr": null
+        },
+        "biomass": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 1451.5,
+          "diff_mwh": -1451.5,
+          "shape_corr": null
+        },
+        "solar": {
+          "uc_mwh": 1094.5,
+          "measured_mwh": 1094.5,
+          "diff_mwh": 0.0,
+          "shape_corr": 1.0
+        },
+        "wind": {
+          "uc_mwh": 745.0,
+          "measured_mwh": 745.0,
+          "diff_mwh": 0.0,
+          "shape_corr": 1.0
+        },
+        "pumped_hydro": {
+          "uc_mwh": 163.1,
+          "measured_mwh": 147.5,
+          "diff_mwh": 15.6,
+          "shape_corr": -0.06
+        },
+        "battery": {
+          "uc_mwh": 359.0,
+          "measured_mwh": 0.0,
+          "diff_mwh": 359.0,
+          "shape_corr": null
+        }
+      },
+      "share_l1_pp": 21.0,
+      "curtailment_mwh": {
+        "solar": 0.0,
+        "wind": 0.0
+      }
+    },
+    "shikoku": {
+      "company": "shikoku",
+      "demand_measured_mwh": 61518.0,
+      "per_fuel": {
+        "nuclear": {
+          "uc_mwh": 21360.0,
+          "measured_mwh": 20923.0,
+          "diff_mwh": 437.0,
+          "shape_corr": null
+        },
+        "lng": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 2289.0,
+          "diff_mwh": -2289.0,
+          "shape_corr": null
+        },
+        "coal": {
+          "uc_mwh": 66432.5,
+          "measured_mwh": 47737.0,
+          "diff_mwh": 18695.5,
+          "shape_corr": 0.633
+        },
+        "oil": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 1278.0,
+          "diff_mwh": -1278.0,
+          "shape_corr": null
+        },
+        "hydro": {
+          "uc_mwh": 10377.6,
+          "measured_mwh": 8085.0,
+          "diff_mwh": 2292.6,
+          "shape_corr": null
+        },
+        "biomass": {
+          "uc_mwh": 4560.0,
+          "measured_mwh": 6922.0,
+          "diff_mwh": -2362.0,
+          "shape_corr": null
+        },
+        "solar": {
+          "uc_mwh": 2618.0,
+          "measured_mwh": 2618.0,
+          "diff_mwh": 0.0,
+          "shape_corr": 1.0
+        },
+        "wind": {
+          "uc_mwh": 3042.0,
+          "measured_mwh": 3042.0,
+          "diff_mwh": 0.0,
+          "shape_corr": 1.0
+        },
+        "pumped_hydro": {
+          "uc_mwh": 0.0,
+          "measured_mwh": 72.0,
+          "diff_mwh": -72.0,
+          "shape_corr": null
+        },
+        "battery": {
+          "uc_mwh": 315.3,
+          "measured_mwh": 0.0,
+          "diff_mwh": 315.3,
+          "shape_corr": null
+        }
+      },
+      "share_l1_pp": 21.81,
+      "curtailment_mwh": {
+        "solar": 0.0,
+        "wind": 0.0
+      }
+    }
+  },
+  "summary": {
+    "l1_pp_by_region": {
+      "hokkaido": 39.73,
+      "tohoku": 51.65,
+      "tokyo": 28.93,
+      "hokuriku": 21.0,
+      "shikoku": 21.81
+    },
+    "l1_pp_mean": 32.62
+  }
+}

--- a/scripts/uc_validate.py
+++ b/scripts/uc_validate.py
@@ -115,6 +115,9 @@ def main() -> int:
                     help="新形式在庫のある会社（カンマ区切り）")
     ap.add_argument("--force-fetch", action="store_true",
                     help="DataSpaceキャッシュを無視して実績を再取得")
+    ap.add_argument("--re-actuals", action="store_true",
+                    help="検証地域のsolar/windをその日の実績系列で置換して"
+                         "UCを解く（天気を所与にして運用だけを比較する検証）")
     ap.add_argument("--out", default=None)
     args = ap.parse_args()
     companies = [c.strip() for c in args.companies.split(",") if c.strip()]
@@ -132,17 +135,9 @@ def main() -> int:
         (cfg.raw.setdefault("demand", {})
             .setdefault("profile_ref", {}))["representative_day"] = args.date
         print(f"代表日を差し替え: {rep} → {args.date}")
-    print(f"UC求解中... ({args.scenario} @ {args.date})")
-    scn = build_national_scenario(scenario=cfg)
-    uc = solve_uc(scn.to_uc_parameters())
-    print(f"  {uc.status}")
-    if not uc.is_optimal:
-        return 1
-
-    # ── 2. 実績取得（必要月×社のみ、DataSpace経由=キャッシュ+provenance） ──
+    # ── 実績の先行取得（--re-actualsはUC構築前に必要） ──
     ds = DataSpace()
-    report_regions = {}
-    l1_rows = []
+    meas_by_region = {}
     for company in companies:
         region = COMPANY_TO_REGION[company]
         print(f"実績取得: {company} ({region}) {month} ...")
@@ -150,7 +145,30 @@ def main() -> int:
                             {"company": company, "month": month,
                              "date": args.date},
                             force=args.force_fetch)
-        meas = measured_region_fuel_24h(meas_raw["rows"], args.date)
+        meas_by_region[region] = measured_region_fuel_24h(
+            meas_raw["rows"], args.date)
+
+    print(f"UC求解中... ({args.scenario} @ {args.date}"
+          + (", RE=実績" if args.re_actuals else "") + ")")
+    scn = build_national_scenario(scenario=cfg)
+    if args.re_actuals:
+        import numpy as _np
+        for region, meas in meas_by_region.items():
+            for key, attr in (("solar", "solar_gen_r"), ("wind", "wind_gen_r")):
+                series = meas.get(key)
+                if series and len(series) == scn.num_periods:
+                    getattr(scn, attr)[region] = _np.asarray(series, dtype=float)
+    uc = solve_uc(scn.to_uc_parameters())
+    print(f"  {uc.status}")
+    if not uc.is_optimal:
+        return 1
+
+    # ── 2. 突合（実績は先行取得済み） ──
+    report_regions = {}
+    l1_rows = []
+    for company in companies:
+        region = COMPANY_TO_REGION[company]
+        meas = meas_by_region[region]
         ucr = uc_region_fuel_24h(scn, uc, region)
 
         fuels = sorted(set(UC_TO_MEASURED) & (set(ucr) | {"solar", "wind"}))
@@ -201,6 +219,7 @@ def main() -> int:
             "git_head": _git_head(),
             "scenario": args.scenario,
             "validation_date": args.date,
+            "re_actuals": bool(args.re_actuals),
             "companies": companies,
             "vocabulary_notes": [
                 "UC oil = 実績 火力(石油)+火力(その他)（区分差の開示）",
@@ -218,8 +237,9 @@ def main() -> int:
             if any(v is not None for _, v in l1_rows) else None,
         },
     }
+    suffix = "_reactuals" if args.re_actuals else ""
     out = args.out or (f"docs/reports/uc_validation_{args.scenario}_"
-                       f"{args.date}.json")
+                       f"{args.date}{suffix}.json")
     with open(out, "w") as f:
         json.dump(report, f, ensure_ascii=False, indent=2)
     print(f"Saved: {out}")


### PR DESCRIPTION
自己改善4巡目（台帳⑳）。tokyo日曜悪化の真因=天気（solar実績16 vs 想定78GWh）。--re-actualsで天気を所与化し運用だけを比較: tokyo 52.6→28.9pp、平均32.6pp。単日検証には天気正規化が必須という手法進化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)