### PR TITLE
UC 22: kansai validation online (legacy parser + measured-demand mode) — L1 23.7pp

### DIFF
--- a/docs/reports/IMPROVEMENT_LOG.md
+++ b/docs/reports/IMPROVEMENT_LOG.md
@@ -131,6 +131,22 @@ KPIは `ajgrid validate --topology --all --solve` の計測値
 <!-- ── UC改善シリーズ（worktree uc-improvements） ── -->
 
 
+## 2026-06-12 — **Fable 5** — UC改善㉒: Phase B — kansai検証の開通（旧形式パーサ+実績需要モード）
+
+- **kansai旧形式パーサ**（nas03コネクタ）: DATE_TIME 1列・1時間値MWh・
+  **火力合算**の関西独自形式をフォールバック実装（列位置固定、テスト7 passed）。
+  uc_validate側は thermal(combined)=UC lng+coal+oil 合算で突合（語彙開示）
+- **--demand-from-measured**: OCCTO実測需要の**保持窓~14ヶ月**の外の日付
+  （kansai月次在庫は2023-12まで）に対応 — 検証地域のグロス需要を実績demand
+  系列で与え、他地域は合成フォールバック（metaに開示）。
+  kansai/2024.csvはHTML破損（NAS側のdemand_update取得失敗、要修繕と開示）
+- **kansai 2023-12-13(水) 検証**: **L1 23.7pp**（良好圏）。乖離主因=
+  **原子力断面差**（UC=fy2025断面6.6GWフル vs 実績4.9GW平均=当時定検中）
+  +40.7GWh/日、その分thermal -31.3 — 検証機構が断面不一致を正しく検出
+- 検証カバレッジ: 5社（2025-08新形式）+kansai（〜2023-12旧形式）=**6社開通**。
+  残り: chubu（年度別形式）/chugoku/kyushu（旧形式）/okinawa
+- ループ累計: ピーク日37.9pp / 天気正規化32.6pp / kansai初値23.7pp
+
 ## 2026-06-12 — **Fable 5** — UC改善㉑: 地熱の坑井重複集約 — 全国549MW=公表値一致
 
 - **真因**: 葛根田地熱がOSMの坑井・設備ポイントで**10重複**（530MW計上 vs

--- a/docs/reports/uc_validation_fy2025r1_2023-12-13_reactuals.json
+++ b/docs/reports/uc_validation_fy2025r1_2023-12-13_reactuals.json
@@ -1,0 +1,80 @@
+{
+  "meta": {
+    "date": "2026-06-12",
+    "git_head": "c693f2f",
+    "scenario": "fy2025r1",
+    "validation_date": "2023-12-13",
+    "re_actuals": true,
+    "demand_from_measured": true,
+    "disclosure": "検証地域=実績需要・他地域=合成needs・原子力断面=シナリオ断面のまま",
+    "companies": [
+      "kansai"
+    ],
+    "vocabulary_notes": [
+      "UC oil = 実績 火力(石油)+火力(その他)（区分差の開示）",
+      "UC solar/wind はシナリオ参照値（fy2025r1はFY2023容量踏襲=FY2025導入増未較正のバイアスをここで実測する）",
+      "実績は30分MW平均→1h平均、UCは1h値"
+    ]
+  },
+  "regions": {
+    "kansai": {
+      "company": "kansai",
+      "demand_measured_mwh": 384947.0,
+      "per_fuel": {
+        "nuclear": {
+          "uc_mwh": 157872.0,
+          "measured_mwh": 117140.0,
+          "diff_mwh": 40732.0,
+          "shape_corr": null
+        },
+        "hydro": {
+          "uc_mwh": 19003.2,
+          "measured_mwh": 31302.0,
+          "diff_mwh": -12298.8,
+          "shape_corr": null
+        },
+        "biomass": {
+          "uc_mwh": 2700.0,
+          "measured_mwh": 1536.0,
+          "diff_mwh": 1164.0,
+          "shape_corr": null
+        },
+        "solar": {
+          "uc_mwh": 22376.0,
+          "measured_mwh": 22376.0,
+          "diff_mwh": 0.0,
+          "shape_corr": 1.0
+        },
+        "wind": {
+          "uc_mwh": 1697.0,
+          "measured_mwh": 1697.0,
+          "diff_mwh": 0.0,
+          "shape_corr": 1.0
+        },
+        "battery": {
+          "uc_mwh": 630.5,
+          "measured_mwh": 0.0,
+          "diff_mwh": 630.5,
+          "shape_corr": null
+        },
+        "thermal(combined)": {
+          "uc_mwh": 158859.6,
+          "measured_mwh": 190155.0,
+          "diff_mwh": -31295.4,
+          "shape_corr": 0.57
+        }
+      },
+      "share_l1_pp": 23.65,
+      "curtailment_mwh": {
+        "solar": 0.0,
+        "wind": 0.0
+      }
+    }
+  },
+  "summary": {
+    "l1_pp_by_region": {
+      "kansai": 23.65
+    },
+    "l1_pp_mean": 23.65
+  }
+}

--- a/scripts/uc_validate.py
+++ b/scripts/uc_validate.py
@@ -115,6 +115,10 @@ def main() -> int:
                     help="新形式在庫のある会社（カンマ区切り）")
     ap.add_argument("--force-fetch", action="store_true",
                     help="DataSpaceキャッシュを無視して実績を再取得")
+    ap.add_argument("--demand-from-measured", action="store_true",
+                    help="検証地域のグロス需要を実績demand系列で与える"
+                         "（OCCTO保持窓~14ヶ月の外の日付用。他地域は合成"
+                         "フォールバック、metaに開示）")
     ap.add_argument("--re-actuals", action="store_true",
                     help="検証地域のsolar/windをその日の実績系列で置換して"
                          "UCを解く（天気を所与にして運用だけを比較する検証）")
@@ -148,9 +152,21 @@ def main() -> int:
         meas_by_region[region] = measured_region_fuel_24h(
             meas_raw["rows"], args.date)
 
+    if args.demand_from_measured:
+        # OCCTO窓外: profile_refを外して合成へ、検証地域のみ実績needsに置換
+        cfg.demand_profile_ref.clear()
+        (cfg.raw.get("demand") or {}).pop("profile_ref", None)
     print(f"UC求解中... ({args.scenario} @ {args.date}"
-          + (", RE=実績" if args.re_actuals else "") + ")")
+          + (", RE=実績" if args.re_actuals else "")
+          + (", 需要=実績(検証地域)" if args.demand_from_measured else "")
+          + ")")
     scn = build_national_scenario(scenario=cfg)
+    if args.demand_from_measured:
+        import numpy as _np2
+        for region, meas in meas_by_region.items():
+            dem = meas.get("demand")
+            if dem and len(dem) == scn.num_periods:
+                scn.gross_demand_r[region] = _np2.asarray(dem, dtype=float)
     if args.re_actuals:
         import numpy as _np
         for region, meas in meas_by_region.items():
@@ -193,6 +209,23 @@ def main() -> int:
                 "diff_mwh": round(uc_mwh - m_mwh, 1),
                 "shape_corr": corr,
             }
+        # 旧形式（火力合算）: UC lng+coal+oil を thermal(combined) として突合
+        if "thermal_combined" in meas:
+            uc_th = float(sum(np.sum(ucr.get(f, []))
+                              for f in ("lng", "coal", "oil")))
+            m_th = float(np.sum(meas["thermal_combined"]))
+            us = np.array([sum(ucr.get(f, [0.0] * 24)[h]
+                               for f in ("lng", "coal", "oil"))
+                           for h in range(24)])
+            ms = np.array(meas["thermal_combined"])
+            corr = (round(float(np.corrcoef(us, ms)[0, 1]), 3)
+                    if us.std() > 1e-6 and ms.std() > 1e-6 else None)
+            per_fuel["thermal(combined)"] = {
+                "uc_mwh": round(uc_th, 1), "measured_mwh": round(m_th, 1),
+                "diff_mwh": round(uc_th - m_th, 1), "shape_corr": corr,
+            }
+            for f in ("lng", "coal", "oil"):   # 個別行は実績側が無く誤誘導
+                per_fuel.pop(f, None)
         uc_tot = sum(v["uc_mwh"] for v in per_fuel.values())
         m_tot = sum(v["measured_mwh"] for v in per_fuel.values())
         l1_pp = (sum(abs(v["uc_mwh"] / uc_tot - v["measured_mwh"] / m_tot)
@@ -220,6 +253,10 @@ def main() -> int:
             "scenario": args.scenario,
             "validation_date": args.date,
             "re_actuals": bool(args.re_actuals),
+            "demand_from_measured": bool(args.demand_from_measured),
+            "disclosure": ("検証地域=実績需要・他地域=合成needs・原子力断面="
+                           "シナリオ断面のまま"
+                           if args.demand_from_measured else None),
             "companies": companies,
             "vocabulary_notes": [
                 "UC oil = 実績 火力(石油)+火力(その他)（区分差の開示）",

--- a/src/dataspace/connectors/nas03.py
+++ b/src/dataspace/connectors/nas03.py
@@ -124,9 +124,60 @@ class Nas03Connector:
         h_idx = next((i for i, r in enumerate(rows_in)
                       if r and r[0].strip() == "DATE"), None)
         if h_idx is None:
-            raise RuntimeError(
-                f"nas03: {company}/{month}.csv に新形式ヘッダ(DATE,TIME,…)が"
-                f"見つからない — 旧形式（火力合算）はPhase B対応")
+            # kansai旧形式（Phase B）: DATE_TIME 1列・1時間値MWh・火力合算。
+            # 列位置固定（2行ヘッダで7-10列目の実績/抑制は1行目の
+            # 太陽光/風力と組合せ — 位置で確定する方が頑健）
+            kx = next((i for i, r in enumerate(rows_in)
+                       if r and r[0].strip() == "DATE_TIME"), None)
+            if kx is None:
+                raise RuntimeError(
+                    f"nas03: {company}/{month}.csv のヘッダが未知形式 — "
+                    f"DATE/TIME でも DATE_TIME でもない")
+            KANSAI_COLS = ["demand", "nuclear", "thermal_combined", "hydro",
+                           "geothermal", "biomass", "solar",
+                           "solar_curtailed", "wind", "wind_curtailed",
+                           "pumped_hydro", "interconnector"]
+            want_date = str(query.get("date", "")).replace("-", "/")
+            want_alt = None
+            if want_date:
+                y, m, d = want_date.split("/")
+                want_alt = f"{y}/{int(m)}/{int(d)}"
+            out_rows = []
+            for r in rows_in[kx + 1:]:
+                if len(r) < 3 or not r[0].strip():
+                    continue
+                dt_s = r[0].strip()           # "2023/12/13 0:00"
+                date_part = dt_s.split()[0]
+                if want_date and date_part not in (want_date, want_alt):
+                    continue
+                rec: Dict[str, Any] = {"dt": dt_s}
+                ok = False
+                for i, fuel in enumerate(KANSAI_COLS, start=1):
+                    if i >= len(r):
+                        continue
+                    v = r[i].strip().replace(",", "")
+                    if v in ("", "－", "-"):
+                        continue
+                    try:
+                        rec[fuel] = float(v)   # 1時間値MWh = MW平均と同値
+                        ok = True
+                    except ValueError:
+                        continue
+                if ok and "demand" in rec:
+                    out_rows.append(rec)
+            fuels = sorted({k for rec in out_rows for k in rec if k != "dt"})
+            logger.info("nas03 fetch %s/%s (legacy DATE_TIME): %d rows",
+                        company, month, len(out_rows))
+            return {
+                "region": COMPANY_TO_REGION[company],
+                "company": company,
+                "month": month,
+                "date": str(query.get("date", "")) or None,
+                "format": "legacy_datetime",
+                "n_rows": len(out_rows),
+                "fuels": fuels,
+                "rows": out_rows,
+            }
         header = rows_in[h_idx]
         col_map: Dict[int, str] = {}
         for i, col in enumerate(header):

--- a/tests/test_nas03_connector.py
+++ b/tests/test_nas03_connector.py
@@ -94,3 +94,28 @@ class TestParser:
 def test_company_region_map_covers_10():
     assert len(COMPANY_TO_REGION) == 10
     assert COMPANY_TO_REGION["tepco"] == "tokyo"
+
+
+CSV_KANSAI_LEGACY = """,,,,,,,太陽光,太陽光,風力,風力,,
+DATE_TIME,エリア需要〔MWh〕,原子力〔MWh〕,火力〔MWh〕,水力〔MWh〕,地熱〔MWh〕,バイオマス〔MWh〕,実績〔MWh〕,抑制量〔MWh〕,実績〔MWh〕,抑制量〔MWh〕,揚水〔MWh〕,連系線〔MWh〕
+2023/12/13 0:00,11734,4961,6364,1114,0,80,0,0,4,0,33,-823
+2023/12/13 1:00,11512,4961,6580,1155,0,80,0,0,2,0,-453,-813
+2023/12/14 0:00,12000,4961,6500,1200,0,80,0,0,3,0,40,-800
+"""
+
+
+def test_kansai_legacy_format(tmp_path):
+    d = tmp_path / "demand_raw" / "kansai"
+    d.mkdir(parents=True)
+    (d / "202312.csv").write_bytes(CSV_KANSAI_LEGACY.encode("cp932"))
+    out = Nas03Connector().fetch(
+        {"company": "kansai", "month": "202312", "date": "2023-12-13"},
+        _FakeContract(str(tmp_path)))
+    assert out["format"] == "legacy_datetime"
+    assert out["region"] == "kansai"
+    assert out["n_rows"] == 2          # 12/14は除外
+    r0 = out["rows"][0]
+    assert r0["nuclear"] == pytest.approx(4961.0)
+    assert r0["thermal_combined"] == pytest.approx(6364.0)
+    assert r0["pumped_hydro"] == pytest.approx(33.0)
+    assert r0["interconnector"] == pytest.approx(-823.0)


### PR DESCRIPTION
自己改善6巡目（台帳㉒）。関西独自形式のパーサ+OCCTO窓外対応(--demand-from-measured)で6社目の検証開通。kansai L1 23.7pp、乖離主因=原子力断面差の正検出。テスト7 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)